### PR TITLE
[extend-rule] Fix ED link

### DIFF
--- a/css-extend-rule/index.bs
+++ b/css-extend-rule/index.bs
@@ -5,7 +5,7 @@ Abstract: This module defines the ''@extend'' rule, which allows elements to act
 	when some new type of element should act like an existing element,
 	but with tweaks.
 Editor: Tab Atkins, Google, http://xanthir.com
-ED: tabatkins.github.io/specs/css-extend-rule/
+ED: https://tabatkins.github.io/specs/css-extend-rule/
 Status: DREAM
 Shortname: extend-rule
 Level: 1


### PR DESCRIPTION
Clicking the **This version** link at https://tabatkins.github.io/specs/css-extend-rule/ takes one to a non-working link: https://tabatkins.github.io/specs/css-extend-rule/tabatkins.github.io/specs/css-extend-rule/.

This fixes that non-working link. Resolves #39