### PR TITLE
[extend-rule] Change `@extend` rule and placeholder selector mechanics

### DIFF
--- a/css-extend-rule/index.bs
+++ b/css-extend-rule/index.bs
@@ -179,7 +179,7 @@ as long as the rule it's inside of matches them.
 <div class='example'>
 	The ''@extend'' rule effectively adds qualities to an element,
 	so that it matches other rules.
-	The selector used to apply the ''@extend'' rule has no effect on this.
+	However, the selector used to apply the ''@extend'' rule still determines the specificity.
 	For example, in the following code:
 
 	<pre class='lang-css'>
@@ -190,24 +190,10 @@ as long as the rule it's inside of matches them.
 	div { @extend .blue-text; }
 	</pre>
 
-	A naive author looking at the code and wondering how a <code>&lt;div id=sidebar></code> element would be styled
-	might assume that it gets red text,
+	The <code>&lt;div id=sidebar></code> element would be styled with red text,
 	as an ID selector is used to ''@extend'' the ''.red-text'' class,
 	versus a much less specific tagname selector.
-	However, this is wrong--
-	the element gets blue text,
-	as the ''.red-text'' and ''.blue-text'' rules have equal specificity,
-	and the ''.blue-text'' rule appears later in the stylesheet.
-	The specificity of the rules that caused the element to match ''.red-text'' or ''.blue-text'' are irrelevant here.
-
-	While this may in some cases be confusing,
-	it can also be a great benefit in some cases.
-	For example,
-	an author can define a lot of styles with simple, one-class (or one <a>placeholder selector</a>) rules,
-	effectively ignoring specificity entirely,
-	then apply them via longer, much more specific selectors,
-	using ''@extend'' to invoke the behavior of the simpler rules.
-	This can allow an author to avoid many of the specificity problems of using IDs in rules, for example.
+	The specificity of the rules that caused the element to extend ''.red-text'' or ''.blue-text'' are relevant here.
 </div>
 
 ''@extend'' Chaining {#extend-chaining}
@@ -244,15 +230,18 @@ not because it's a separate feature that needs to be specifically defined.
 	is equivalent to the following code without ''@extend'':
 
 	<pre class='lang-css'>
-	.error, .serious-error, .super-serious-error {
+	.error {
 		color: red;
 	}
 
-	.serious-error, .super-serious-error {
+	.serious-error {
+		color: red;
 		font-weight: bold;
 	}
 
 	.super-serious-error {
+		color: red;
+		font-weight: bold;
 		animation: flashing 1s infinite;
 	}
 	</pre>

--- a/css-extend-rule/index.bs
+++ b/css-extend-rule/index.bs
@@ -321,10 +321,10 @@ This ensures that no element will ever directly match the styles using one,
 even by accident,
 and it can't be accidentally reused for an element directly.
 
-<a>Placeholder selectors</a> have the same specificity as <a>class selectors</a>.
+<a>Placeholder selectors</a> have the same specificity as <a>universal selectors</a>.
 
-Issue: Or should they have slightly less, so concrete classes can reliably override?
-This would mean putting a fourth number into the specificity 3-tuple.
+Issue: Or should they have greater specificity?
+Or should we put a fourth number into the specificity 3-tuple?
 
 Acknowledgements {#acks}
 ========================

--- a/css-extend-rule/index.bs
+++ b/css-extend-rule/index.bs
@@ -5,7 +5,7 @@ Abstract: This module defines the ''@extend'' rule, which allows elements to act
 	when some new type of element should act like an existing element,
 	but with tweaks.
 Editor: Tab Atkins, Google, http://xanthir.com
-ED: tabatkins.github.io/specs/css-extend-rule/
+ED: https://tabatkins.github.io/specs/css-extend-rule/
 Status: DREAM
 Shortname: extend-rule
 Level: 1


### PR DESCRIPTION
This hopes to resolve #40 by changing the `@extend` rule and placeholder selector so that:

- The specificity of the rules that cause an element to extend are relevant, and;
- The specificity of the rules being extended are irrelevant.
- The specificity of placeholder selectors is the same as universal selectors, as the previous change makes its specificity irrelevant.

My hope is that this actually simplifies extend, improving the comprehension of specificity by placing on the conditions of its evocation. Manipulation of specificity seems better handled by the resolution of w3c/csswg-drafts#1170.

Compatible with and also resolves #71