### PR TITLE
Fix typo (s/and/also/)

### DIFF
--- a/construct-stylesheets/index.bs
+++ b/construct-stylesheets/index.bs
@@ -57,7 +57,7 @@ ShadowRoot implements TreeScope;
 			set <var>sheet’s</var> disabled flag.
 		5. <a spec=css-syntax-3>Parse a stylesheet</a> from {{text}}.
 			If it returned a list of rules,
-			also assign the list as <var>sheet’s</var> CSS rules;
+			assign the list as <var>sheet’s</var> CSS rules;
 			otherwise,
 			set <var>sheet’s</var> CSS rules to an empty list.
 		6. Return <var>sheet</var>.

--- a/construct-stylesheets/index.bs
+++ b/construct-stylesheets/index.bs
@@ -57,7 +57,7 @@ ShadowRoot implements TreeScope;
 			set <var>sheet’s</var> disabled flag.
 		5. <a spec=css-syntax-3>Parse a stylesheet</a> from {{text}}.
 			If it returned a list of rules,
-			and assign the list as <var>sheet’s</var> CSS rules;
+			also assign the list as <var>sheet’s</var> CSS rules;
 			otherwise,
 			set <var>sheet’s</var> CSS rules to an empty list.
 		6. Return <var>sheet</var>.


### PR DESCRIPTION
Currently it says "Parse a stylesheet (etc). If it returned a list of rules, and assign (etc)."  This doesn't really make sense.

I think it means to say "also assign", not "and assign".