### PR TITLE
when-else: Switch 'or' to 'and' in example to match expected output

### DIFF
--- a/css-when-else/index.bs
+++ b/css-when-else/index.bs
@@ -134,7 +134,7 @@ An ''@else'' rule that is not part of a <a>conditional rule chain</a> is invalid
 	<pre class="lang-css">
 		@when media(width >= 400px) and media(pointer: fine) and supports(display: flex) {
 			/* A */
-		} @else supports(caret-color: pink) or supports(background: double-rainbow()) {
+		} @else supports(caret-color: pink) and supports(background: double-rainbow()) {
 			/* B */
 		} @else {
 			/* C */

--- a/css-when-else/index.html
+++ b/css-when-else/index.html
@@ -1533,7 +1533,7 @@ regardless of what they contain.</p>
     <a class="self-link" href="#example-a3ad87c9"></a> For example, here’s a (somewhat silly) conditional chain: 
 <pre class="lang-css highlight"><span class="n">@when</span> <span class="nf">media</span><span class="p">(</span>width <span class="nt">>= 400px) and media(pointer: fine) and supports(display: flex) </span><span class="p">{</span>
   <span class="c">/* A */</span>
-<span class="p">}</span> <span class="n">@else</span> <span class="nf">supports</span><span class="p">(</span>caret-color<span class="nt">: pink) or supports(background: double-rainbow()) </span><span class="p">{</span>
+<span class="p">}</span> <span class="n">@else</span> <span class="nf">supports</span><span class="p">(</span>caret-color<span class="nt">: pink) and supports(background: double-rainbow()) </span><span class="p">{</span>
   <span class="c">/* B */</span>
 <span class="p">}</span> <span class="n">@else</span> <span class="err">{</span>
   <span class="c">/* C */</span>


### PR DESCRIPTION
The expected output indicates this should be `or`, not `and`.