### PR TITLE
Shared element transitions: Prefers reduced motion handling

### DIFF
--- a/css-shared-element-transitions/index.bs
+++ b/css-shared-element-transitions/index.bs
@@ -351,9 +351,15 @@ partial interface Document {
 
 dictionary DOMTransitionInit {
     required UpdateDOMCallback updateDOM;
+    ReducedMotionHandling reducedMotionHandling = "auto";
 };
 
 callback UpdateDOMCallback = Promise<any> ();
+
+enum ReducedMotionHandling {
+    "auto",
+    "manual",
+};
 </script>
 
 ### {{Document/createTransition()}} ### {#DOMTransition-prepare}
@@ -374,7 +380,11 @@ callback UpdateDOMCallback = Promise<any> ();
 
         Note: This can result in two asynchronous [=DOMTransition/DOM update callbacks=] running concurrently. One for the |document|'s current [=active DOM transition=], and another for this |transition|. As per the [design of this feature](#transitions-as-enhancements), it's assumed that the developer is using another feature or framework to correctly schedule these DOM changes.
 
-    1. Set |document|'s [=active DOM transition=] to |transition|.
+    1. If |init|[{{DOMTransitionInit/reducedMotionHandling}}] is {{ReducedMotionHandling/"auto"}}, and the user has requested the system minimize the amount of non-essential motion it uses, such that the '@media/prefers-reduced-motion' [=media query=] would match ''prefers-reduced-motion/reduce'', then [=skip the page transition=] |transition| with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
+
+        Issue: It feels like there should be a better way to handle this than going via media queries. Perhaps we should centralize the definition of requesting the system for reduced motion.
+
+    1. Otherwise, set |document|'s [=active DOM transition=] to |transition|.
 
         Note: The process continues in [=perform an outgoing capture=].
 

--- a/css-shared-element-transitions/index.bs
+++ b/css-shared-element-transitions/index.bs
@@ -350,7 +350,7 @@ partial interface Document {
 };
 
 dictionary DOMTransitionInit {
-    UpdateDOMCallback updateDOM;
+    required UpdateDOMCallback updateDOM;
 };
 
 callback UpdateDOMCallback = Promise<any> ();

--- a/css-shared-element-transitions/index.bs
+++ b/css-shared-element-transitions/index.bs
@@ -260,10 +260,6 @@ The precise tree structure, and in particular the order of sibling
 pseudo-elements, is defined in the [=Create transition pseudo-elements=]
 algorithm.
 
-Styles applied to these pseudo-elements are limited to styles in the
-[=user-agent origin=] unless the [=SameDocumentTransition/phase=] associated with them is
-set to "running".
-
 # Concepts # {#concepts}
 
 ## The [=page-transition layer=] stacking layer ## {#page-transition-stacking-layer}
@@ -324,50 +320,103 @@ A {{Document}} additionally has:
 
 <dl dfn-for="document">
     : <dfn>pending same document transition outgoing capture</dfn>
-    :: a {{SameDocumentTransition}} or null. Initially null.
+    :: a {{DOMTransition}} or null. Initially null.
 
     : <dfn>running same document transition</dfn>
-    :: a {{SameDocumentTransition}} or null. Initially null.
+    :: a {{DOMTransition}} or null. Initially null.
+
+    : <dfn>transition suppressing rendering</dfn>
+    :: a {{DOMTransition}} or null. Initially null.
 </dl>
 
 # API # {#api}
 
-## The {{SameDocumentTransition}} interface ## {#the-samedocumenttransition-interface}
+## Additions to {{Document}} ## {#additions-to-document-api}
 
 <script type=idl>
-interface SameDocumentTransition {
-    constructor();
-    Promise<undefined> prepare(PrepareCallback cb);
-    undefined abandon();
-    readonly attribute Promise<undefined> finished;
+partial interface Document {
+    DOMTransition createTransition(DOMTransitionInit init);
 };
 
-callback PrepareCallback = Promise<any> ();
+dictionary DOMTransitionInit {
+    ChangeDOMCallback changeDOM;
+};
+
+callback ChangeDOMCallback = Promise<any> ();
+</script>
+
+### {{Document/createTransition()}} ### {#DOMTransition-prepare}
+
+<div algorithm>
+    The [=method steps=] for
+    <dfn method for=Document>createTransition(|init|)</dfn>
+    are as follows:
+
+    1. Let |transition| be a new {{DOMTransition}} object in [=this's=] [=relevant Realm=].
+
+    1. Set |transition|'s [=DOMTransition/DOM change callback=] to |init|[{{DOMTransitionInit/changeDOM}}].
+
+    1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
+
+    1. Let |transitionsToSkip| be a [=/list=] of every {{DOMTransition}}
+        within [=this's=] [=relevant Realm=],
+        that has not [=DOMTransition/concluded=],
+        and is not |transition|.
+
+    1. Assert: The [=list/size=] of |transitionsToSkip| is 0 or 1.
+
+    1. [=list/For each=] |transitionToSkip| of |transitionsToSkip|, [=skip the page transition=] |transitionToSkip| with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
+
+    1. [=Assert=]: |document|'s [=document/pending same document transition outgoing capture=] is null.
+
+    1. Set |document|'s [=document/pending same document transition outgoing capture=] to |transition|.
+
+        Note: This process continues in [=perform an outgoing capture=].
+
+    1. Return |transition|.
+
+</div>
+
+## The {{DOMTransition}} interface ## {#the-domtransition-interface}
+
+<script type=idl>
+interface DOMTransition {
+    undefined skipTransition();
+    readonly attribute Promise<undefined> finished;
+    readonly attribute Promise<undefined> ready;
+    readonly attribute Promise<undefined> domUpdated;
+};
 </script>
 
 <div class="note">
-    The {{SameDocumentTransition}} represents and controls
+    The {{DOMTransition}} represents and controls
     a single same-document transition. That is, it controls a transition where the
     starting and ending document are the same, possibly with changes to the
     document's DOM structure.
 </div>
 
-{{SameDocumentTransition}} objects have the following:
+A {{DOMTransition}} has the following:
 
-<dl dfn-for="SameDocumentTransition">
+<dl dfn-for="DOMTransition">
     : <dfn>tagged elements</dfn>
     :: a [=/map=],
         whose keys are [=page transition tags=] and whose values are [=captured elements=].
         Initially a new [=map=].
 
-    : <dfn>phase</dfn>
-    :: "`idle`", "`preparing`", "`running`", or "`finished`".
-        Initially "`idle`".
+    : <dfn>concluded</dfn>
+    :: a boolean. Initially false.
 
-    : <dfn>prepare callback</dfn>
-    :: a {{PrepareCallback}} or null. Initially null.
+    : <dfn>DOM change callback</dfn>
+    :: a {{ChangeDOMCallback}} or null. Initially null.
+
+    : <dfn>DOM change callback called</dfn>
+    :: a boolean. Initially false.
 
     : <dfn>ready promise</dfn>
+    :: a {{Promise}}.
+        Initially [=a new promise=] in [=this's=] [=relevant Realm=].
+
+    : <dfn>DOM updated promise</dfn>
     :: a {{Promise}}.
         Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
@@ -376,51 +425,19 @@ callback PrepareCallback = Promise<any> ();
         Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 </dl>
 
-The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=] [=SameDocumentTransition/finished promise=].
+The {{DOMTransition/finished}} [=getter steps=] are to return [=this's=] [=DOMTransition/finished promise=].
 
-### {{SameDocumentTransition/prepare()}} ### {#SameDocumentTransition-prepare}
+The {{DOMTransition/ready}} [=getter steps=] are to return [=this's=] [=DOMTransition/ready promise=].
 
-<div algorithm="SameDocumentTransition.prepare()">
-    The [=method steps=] for
-    <dfn method for=SameDocumentTransition>prepare(|cb|)</dfn>
-    are as follows:
+The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOMTransition/DOM updated promise=].
 
-    1. If [=this's=] [=SameDocumentTransition/phase=] is not "`idle`", then throw an "{{InvalidStateError}}" {{DOMException}}.
-
-    1. Set [=this's=] [=SameDocumentTransition/phase=] to "`preparing`".
-
-    1. Set [=this's=] [=SameDocumentTransition/prepare callback=] to |cb|.
-
-    1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
-
-    1. Let |transitionsToAbandon| be a [=/list=] of every {{SameDocumentTransition}}
-        within [=this's=] [=relevant Realm=]
-        that has a [=SameDocumentTransition/phase=] that is not "`idle`".
-
-        Issue: The ordering needs to be defined, probably in a queue.
-
-    1. [=list/For each=] |transition| of |transitionsToAbandon|,
-        [=abandon the page transition=] |transition| with an "{{AbortError}}" {{DOMException}}.
-
-        Issue: The callbacks may still be running after this, which may not be what we want.
-
-    1. [=Assert=]: |document|'s [=document/pending same document transition outgoing capture=] is null.
-
-    1. Set |document|'s [=document/pending same document transition outgoing capture=] to [=this=].
-
-    1. Return [=this's=] [=SameDocumentTransition/ready promise=].
-
-    Note: This process continues in [=perform an outgoing capture=].
-</div>
-
-### {{SameDocumentTransition/abandon()}} ### {#SameDocumentTransition-abandon}
+### {{DOMTransition/skipTransition()}} ### {#DOMTransition-skipTransition}
 
 <div algorithm>
-    The [=method steps=] for
-    <dfn method for=SameDocumentTransition>abandon()</dfn> are:
+    The [=method steps=] for <dfn method for="DOMTransition">skipTransition()</dfn> are:
 
-    1. If [=this's=] [=SameDocumentTransition/phase=] is not "`finished`",
-        then [=abandon the page transition=] [=this=]
+    1. If [=this=] has not [=DOMTransition/concluded=],
+        then [=skip the page transition=] for [=this=]
         with an "{{AbortError}}" {{DOMException}}.
 </div>
 
@@ -457,14 +474,12 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 ## [=Perform an outgoing capture=] ## {#perform-an-outgoing-capture-algorithm}
 
 <div algorithm>
-    To <dfn>perform an outgoing capture</dfn> given a {{SameDocumentTransition}} |transition|,
+    To <dfn>perform an outgoing capture</dfn> given a {{DOMTransition}} |transition|,
         perform the following steps:
 
-    1. Let |taggedElements| be |transition|'s [=SameDocumentTransition/tagged elements=].
+    1. Let |taggedElements| be |transition|'s [=DOMTransition/tagged elements=].
 
     1. Let |usedTransitionTags| be a new [=/set=] of strings.
-
-    1. Let |preparationFailed| be false.
 
     1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
@@ -488,7 +503,9 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
             * |element| is not |element|'s [=tree/root=] and |element| allows [=fragmentation=].
 
-            Then set |preparationFailed| to true and [=break=].
+            Then [=skip the page transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}}
+                in |transition|'s [=relevant Realm=],
+                and return.
 
         1. [=set/Append=] |transitionTag| to |usedTransitionTags|.
 
@@ -524,6 +541,8 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
         1. Set |taggedElements|[|transitionTag|] to |capture|.
 
+    1. Set [=document/transition suppressing rendering=] to |transition|.
+
     1. Suppress rendering opportunities for |transition|'s [=relevant global object's=] [=associated document=].
 
         Note: The aim is to prevent unintended DOM updates from being presented to the
@@ -547,34 +566,25 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
             Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
                 although the render steps in the HTML spec act as if it's synchronous.
 
-        1. Let |timedOut| be false.
+        1. If |transition| has [=DOMTransition/concluded=], then abort these steps.
 
-        1. Let |userP| be the result of [=/invoking=] |transition|'s [=SameDocumentTransition/prepare callback=].
+            Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
-        1. [=promise/React=] to |userP|:
+        1. [=Call the DOM change callback=] of |transition|.
 
-            * If |userP| does not settle within an implementation-defined timeout, then:
+        1. [=promise/React=] to |transition|'s [=DOMTransition/DOM updated promise=]:
 
-                1. Set |timedOut| to true.
+            * If the promise does not settle within an implementation-defined timeout, then [=skip the page transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
-                1. If |preparationFailed| is true,
-                    then [=abandon the page transition=] |transition| with an "{{AbortError}}" {{DOMException}},
-                    and abort these steps.
+            * If the promise was fulfilled, then:
 
-                1. Otherwise, [=abandon the page transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+                1. If |transition| has [=DOMTransition/concluded=], then return.
 
-            * If |userP| was fulfilled, then:
+                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
-                1. If |timedOut| is true, then return.
+                1. Set [=document/transition suppressing rendering=] to null.
 
                 1. Stop suppressing rendering opportunities for |transition|'s Document.
-
-                    Note: Resuming rendering opportunities is delayed until fulfillment of
-                    |userP| to allow asynchronous loading of the incoming DOM.
-
-                1. If |preparationFailed| is true,
-                    then [=abandon the page transition=] |transition| with an "{{AbortError}}" {{DOMException}},
-                    and return.
 
                 1. Set |usedTransitionTags| to a new [=/set=].
 
@@ -600,7 +610,7 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
                         * |element| is not |element|'s [=tree/root=]
                             and |element| allows [=fragmentation=].
 
-                        Then [=abandon the page transition=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
+                        Then [=skip the page transition=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
                             and return.
 
                     1. [=set/Append=] |transitionTag| to |usedTransitionTags|.
@@ -612,8 +622,6 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
                     1. Let |capture|'s [=incoming element=] item be |element|.
 
-                1. Set |transition|'s [=SameDocumentTransition/phase=] "`running`".
-
                 1. [=Create transition pseudo-elements=] for |transition|.
 
                 1. [=Animate a page transition=] |transition|.
@@ -623,17 +631,15 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
                     Note: The frame-by-frame parts of the animation are handled in [=update transition DOM=].
 
-                1. [=Resolve=] [=SameDocumentTransition/ready promise=].
+                1. [=Resolve=] [=DOMTransition/ready promise=].
 
-            * If |userP| was rejected with reason |r|, then:
+            * If the promise was rejected with reason |r|, then:
 
-                1. If |timedOut| is true, then return.
+                1. If |transition| has [=DOMTransition/concluded=], then return.
 
-                1. Let |reason| be an "{{AbortError}}" {{DOMException}}
-                    if |preparationFailed| is true,
-                    otherwise |r|.
+                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
-                1. [=Abandon the page transition=] |transition| with |reason|.
+                1. [=Skip the page transition=] |transition| with |r|.
 </div>
 
 <div class=example>
@@ -643,7 +649,7 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
     and a single line of script to start it:
 
     <pre highlight=js>
-    new SameDocumentTransition()
+    new DOMTransition()
       .start(()=>coolFramework.changeTheDOMToPageB());
     </pre>
 
@@ -652,7 +658,7 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
     <pre highlight=js>
     async function doTransition() {
-      let transition = new SameDocumentTransition();
+      let transition = new DOMTransition();
 
       // Specify "outgoing" elements. The tag is used to match against
       // "incoming" elements they should transition to, and to refer to
@@ -692,19 +698,29 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
     </pre>
 </div>
 
-## Abandon the page transition ## {#abandon-the-page-transition-algorithm}
+## Skip the page transition ## {#skip-the-page-transition-algorithm}
 
 <div algorithm>
-    To <dfn>abandon the page transition</dfn> for {{SameDocumentTransition}} |transition|
-    with |error|:
+    To <dfn>skip the page transition</dfn> for {{DOMTransition}} |transition| with reason |reason|:
+
+    1. [=Assert=]: |transition| has not [=DOMTransition/concluded=].
+
+    1. If |transition|'s [=DOMTransition/DOM change callback called=] is false, then [=call the DOM change callback=] of |transition|.
 
     1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-    1. If |transition|'s [=SameDocumentTransition/phase=] is not "`idle`", then:
+    1. If |document|'s [=document/pending same document transition outgoing capture=] is |transition|,
+        then set |document|'s [=document/pending same document transition outgoing capture=] to null.
 
-        1. Stop suppressing rendering opportunities |document|, if currently suppressed.
+    1. If |document|'s [=document/transition suppressing rendering=] is |transition|, then:
+
+        1. Stop suppressing rendering opportunities, if suppressed, for |document|.
 
             Issue: "suppressing rendering opportunities" needs to be linked/defined.
+
+        1. Set |document|'s [=document/transition suppressing rendering=] to null.
+
+    1. If |document|'s [=document/running same document transition=] is |transition|, then:
 
         1. Remove all associated [=page-transition pseudo-elements=] from |document|.
 
@@ -712,17 +728,13 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
             Issue: There needs to be a definition/link for "associated".
 
-    1. Set |transition|'s [=SameDocumentTransition/phase=] to "`finished`".
+        1. Set |document|'s [=document/running same document transition=] to null.
 
-    1. If |document|'s [=document/pending same document transition outgoing capture=] is |transition|,
-        then set |document|'s [=document/pending same document transition outgoing capture=] to null.
+    1. Set |transition|'s [=DOMTransition/concluded=] to true.
 
-    1. If |document|'s [=document/running same document transition=] is |transition|,
-        then set |document|'s [=document/running same document transition=] to null.
+    1. [=Reject=] |transition|'s [=DOMTransition/ready promise=] with |reason|.
 
-    1. [=Reject=] |transition|'s [=SameDocumentTransition/ready promise=] with |error|.
-
-    1. [=Reject=] |transition|'s [=SameDocumentTransition/finished promise=] with |error|.
+    1. [=Reject=] |transition|'s [=DOMTransition/finished promise=] with |reason|.
 </div>
 
 ## [=Capture the image=] ## {#capture-the-image-algorithm}
@@ -763,7 +775,9 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 ## [=Update transition DOM=] ## {#update-transition-dom-algorithm}
 
 <div algorithm>
-    To <dfn>update transition DOM</dfn> given a {{SameDocumentTransition}} |transition|:
+    To <dfn>update transition DOM</dfn> given a {{DOMTransition}} |transition|:
+
+    1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
     1. For each [=page-transition pseudo-elements=] associated with |transition|,
         check whether there is an active animation associated with this pseudo-element.
@@ -772,19 +786,23 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 
     1. If no [=page-transition pseudo-elements=] has an active animation:
 
-        1. Set |transition|'s [=SameDocumentTransition/phase=] to "`finished`".
+        Issue: There needs to be a definition/link for "active animation".
 
-        1. Remove all associated [=page-transition pseudo-elements=] from |transition|'s [=associated document=].
+        1. Set |transition|'s [=DOMTransition/concluded=] to true.
 
-        1. [=Resolve=] |transition|'s[=SameDocumentTransition/finished promise=].
+        1. Remove all associated [=page-transition pseudo-elements=] from |document|.
 
             Issue: There needs to be a definition/link for "remove".
 
             Issue: There needs to be a definition/link for "associated".
 
+        1. Set |document|'s [=document/running same document transition=] to null.
+
+        1. [=Resolve=] |transition|'s[=DOMTransition/finished promise=].
+
         1. Return.
 
-    1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=SameDocumentTransition/tagged elements=]:
+    1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=DOMTransition/tagged elements=]:
 
         1. If |capturedElement| has an "incoming element", run [=capture the image=]
             on |capturedElement|'s "incoming element" and update the displayed
@@ -824,7 +842,7 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 ## [=Animate a page transition=] ## {#animate-a-page-transition-algorithm}
 
 <div algorithm>
-    To <dfn>animate a page transition</dfn> given a {{SameDocumentTransition}} |transition|:
+    To <dfn>animate a page transition</dfn> given a {{DOMTransition}} |transition|:
 
     1. Generate a <<keyframe>> named "page-transition-fade-out" in
         [=user-agent origin=] as follows:
@@ -856,7 +874,7 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
             }
         </code></pre>
 
-    1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=SameDocumentTransition/tagged elements=]:
+    1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=DOMTransition/tagged elements=]:
 
         1. If neither of |capturedElement|'s [=captured element/outgoing image=] or [=captured element/incoming element=] is null:
 
@@ -906,11 +924,11 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
 ## [=Create transition pseudo-elements=] ## {#create-transition-pseudo-elements-algorithm}
 
 <div algorithm>
-    To <dfn>create transition pseudo-elements</dfn> for a {{SameDocumentTransition}} |transition|:
+    To <dfn>create transition pseudo-elements</dfn> for a {{DOMTransition}} |transition|:
 
     1. Let |transitionRoot| be the result of creating a new ''::page-transition'' pseudo-element.
 
-    1. [=map/For each=] |transitionTag| → |capturedElement| of |transition|'s [=SameDocumentTransition/tagged elements=]:
+    1. [=map/For each=] |transitionTag| → |capturedElement| of |transition|'s [=DOMTransition/tagged elements=]:
 
         1. Let |container| be the result of creating a new ''::page-transition-container'' pseudo-element with the tag |transitionTag|.
 
@@ -977,4 +995,21 @@ The {{SameDocumentTransition/finished}} [=getter steps=] are to return [=this's=
             1. At the [=user-agent origin=],
                 set |incoming|'s 'object-view-box' property to a value that when applied to |incoming|,
                 will cause the view box to coincide with [=incoming element=]'s [=border box=] in the image.
+</div>
+
+<div algorithm>
+    To <dfn>call the DOM change callback</dfn> of a {{DOMTransition}} |transition|:
+
+    1. [=Assert=]: |transition|'s [=DOMTransition/DOM change callback called=] is false.
+
+    1. Let |callbackPromise| be the result of [=/invoking=] |transition|'s [=DOMTransition/DOM change callback=].
+
+    1. Set |transition|'s [=DOMTransition/DOM change callback called=] to true.
+
+    1. [=promise/React=] to |callbackPromise|:
+
+        * If |callbackPromise| was fulfilled, then [=resolve=] |transition|'s [=DOMTransition/DOM updated promise=].
+
+        * If |callbackPromise| was rejected with reason |r|, then [=reject=] |transition|'s [=DOMTransition/DOM updated promise=] with |r|.
+
 </div>

--- a/css-shared-element-transitions/index.bs
+++ b/css-shared-element-transitions/index.bs
@@ -40,9 +40,17 @@ spec:css-shapes-3; type:function; text:rect()
 
 # Introduction # {#intro}
 
-    This spec describes the CSS and JS mechanics
-    of the single-page Page Transition API.
+This spec describes the CSS and JS mechanics of the single-page transition API.
 
+# Transitions as an enhancement # {#transitions-as-enhancements}
+
+<em>This section is non-normative.</em>
+
+A key part of this API design is the view that an animated transition is an enhancement to a DOM change.
+
+If a transition cannot run, or is skipped, the DOM change should still happen. If the DOM change should also be skipped, then that should be handled by another feature. The <a href="https://wicg.github.io/navigation-api/#navigate-event-class">`signal` on `NavigateEvent`</a> is an example of a feature developers could use to handle this.
+
+Although the transition API allows DOM changes to be asynchronous via the {{DOMTransitionInit/updateDOM}} callback, the transition API is not responsible for queuing or otherwise scheduling the DOM changes, beyond the scheduling needed for the transition itself. Some asynchronous DOM changes can happen concurrently (e.g if they're happening within independent components), whereas others need to queue, or abort an earlier change. This is best left to a feature or framework that has a more holistic view of the update.
 
 # CSS properties # {#css-properties}
 
@@ -262,6 +270,12 @@ algorithm.
 
 # Concepts # {#concepts}
 
+## Phases ## {#phases-concept}
+
+<dfn>Phases</dfn> represent an ordered sequence of states. Since [=phases=] are ordered, prose can refer to phases <dfn for="phases">before</dfn> a particular phase, meaning they appear earlier in the sequence, or <dfn for="phases">after</dfn> a particular phase, meaning they appear later in the sequence.
+
+The initial phase is the first item in the sequence.
+
 ## The [=page-transition layer=] stacking layer ## {#page-transition-stacking-layer}
 
 This specification introduces a stacking layer to the
@@ -319,14 +333,11 @@ A <dfn>captured element</dfn> is a [=struct=] with the following:
 A {{Document}} additionally has:
 
 <dl dfn-for="document">
-    : <dfn>pending same document transition outgoing capture</dfn>
-    :: a {{DOMTransition}} or null. Initially null.
-
-    : <dfn>running same document transition</dfn>
+    : <dfn>active DOM transition</dfn>
     :: a {{DOMTransition}} or null. Initially null.
 
     : <dfn>transition suppressing rendering</dfn>
-    :: a {{DOMTransition}} or null. Initially null.
+    :: a boolean. Initially false.
 </dl>
 
 # API # {#api}
@@ -339,10 +350,10 @@ partial interface Document {
 };
 
 dictionary DOMTransitionInit {
-    ChangeDOMCallback changeDOM;
+    UpdateDOMCallback updateDOM;
 };
 
-callback ChangeDOMCallback = Promise<any> ();
+callback UpdateDOMCallback = Promise<any> ();
 </script>
 
 ### {{Document/createTransition()}} ### {#DOMTransition-prepare}
@@ -354,27 +365,78 @@ callback ChangeDOMCallback = Promise<any> ();
 
     1. Let |transition| be a new {{DOMTransition}} object in [=this's=] [=relevant Realm=].
 
-    1. Set |transition|'s [=DOMTransition/DOM change callback=] to |init|[{{DOMTransitionInit/changeDOM}}].
+    1. Set |transition|'s [=DOMTransition/DOM update callback=] to |init|[{{DOMTransitionInit/updateDOM}}].
 
     1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-    1. Let |transitionsToSkip| be a [=/list=] of every {{DOMTransition}}
-        within [=this's=] [=relevant Realm=],
-        that has not [=DOMTransition/concluded=],
-        and is not |transition|.
+    1. If |document|'s [=active DOM transition=] is not null, then [=skip the page transition=] |document|'s [=active DOM transition=]
+        with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
 
-    1. Assert: The [=list/size=] of |transitionsToSkip| is 0 or 1.
+        Note: This can result in two asynchronous [=DOMTransition/DOM update callbacks=] running concurrently. One for the |document|'s current [=active DOM transition=], and another for this |transition|. As per the [design of this feature](#transitions-as-enhancements), it's assumed that the developer is using another feature or framework to correctly schedule these DOM changes.
 
-    1. [=list/For each=] |transitionToSkip| of |transitionsToSkip|, [=skip the page transition=] |transitionToSkip| with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
+    1. Set |document|'s [=active DOM transition=] to |transition|.
 
-    1. [=Assert=]: |document|'s [=document/pending same document transition outgoing capture=] is null.
-
-    1. Set |document|'s [=document/pending same document transition outgoing capture=] to |transition|.
-
-        Note: This process continues in [=perform an outgoing capture=].
+        Note: The process continues in [=perform an outgoing capture=].
 
     1. Return |transition|.
+</div>
 
+<div class=example>
+    If the default animations for the page transition are acceptable,
+    then kicking off a transition
+    requires nothing more than setting 'page-transition-tag' in the page's CSS,
+    and a single line of script to start it:
+
+    <pre highlight=js>
+        document.createTransition({
+            updateDOM() {
+                coolFramework.changeTheDOMToPageB();
+            }
+        });
+    </pre>
+
+    If more precise management is needed, however,
+    transition elements can be managed in script:
+
+    <pre highlight=js>
+        async function doTransition() {
+            // Specify "outgoing" elements. The tag is used to match against
+            // "incoming" elements they should transition to, and to refer to
+            // the transitioning pseudo-element.
+            document.querySelector('.old-message').style.pageTransitionTag = 'message';
+
+            const transition = document.createTransition({
+                async updateDOM() {
+                    // This callback is invoked by the browser when "outgoing"
+                    // capture finishes and the DOM can be switched to the new
+                    // state. No frames are rendered until this callback returns.
+
+                    // DOM changes may be asynchronous
+                    await coolFramework.changeTheDOMToPageB();
+
+                    // Tagging elements during the updateDOM() callback marks them as
+                    // "incoming", to be matched up with the same-tagged "outgoing"
+                    // elements marked previously and transitioned between.
+                    document.querySelector('.new-message').style.pageTransitionTag =
+                        'message';
+                },
+            });
+
+            // When ready resolves, all pseudo-elements for this transition have
+            // been generated.
+            // They can now be accessed in script to set up custom animations.
+            await transition.ready;
+
+            document.documentElement.animate(keyframes, {
+                ...animationOptions,
+                pseudoElement: '::page-transition-container(message)',
+            });
+
+            // When the finished promise resolves, that means the transition is
+            // finished.
+            await transition.finished;
+        }
+    </pre>
 </div>
 
 ## The {{DOMTransition}} interface ## {#the-domtransition-interface}
@@ -403,14 +465,16 @@ A {{DOMTransition}} has the following:
         whose keys are [=page transition tags=] and whose values are [=captured elements=].
         Initially a new [=map=].
 
-    : <dfn>concluded</dfn>
-    :: a boolean. Initially false.
+    : <dfn>phase</dfn>
+    :: One of the following [=phases=]:
 
-    : <dfn>DOM change callback</dfn>
-    :: a {{ChangeDOMCallback}} or null. Initially null.
+        1. "`pending-capture`".
+        1. "`dom-update-callback-called`".
+        1. "`animating`".
+        1. "`done`".
 
-    : <dfn>DOM change callback called</dfn>
-    :: a boolean. Initially false.
+    : <dfn>DOM update callback</dfn>
+    :: an {{UpdateDOMCallback}} or null. Initially null.
 
     : <dfn>ready promise</dfn>
     :: a {{Promise}}.
@@ -436,14 +500,14 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 <div algorithm>
     The [=method steps=] for <dfn method for="DOMTransition">skipTransition()</dfn> are:
 
-    1. If [=this=] has not [=DOMTransition/concluded=],
+    1. If [=this=]'s [=DOMTransition/phase=] is not "`done`",
         then [=skip the page transition=] for [=this=]
         with an "{{AbortError}}" {{DOMException}}.
 </div>
 
 # Algorithms # {#algorithms}
 
-## Monkey patch to rendering ## {#monkey-patch-to-rendering-algorithm}
+## Monkey patches to rendering ## {#monkey-patch-to-rendering-algorithm}
 
 <div algorithm="monkey patch to rendering">
     Run the following steps before [marking paint timing](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:mark-paint-timing) in the [=update the rendering=] steps:
@@ -455,20 +519,40 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
         As such, the prose style is written to match other steps in that algorithm.
 </div>
 
+<div algorithm="suppress rendering">
+    Issue: Define where this sits within the [=update the rendering=] steps.
+
+    1. For each {{Document}} in <var ignore>docs</var> with a [=document/transition suppressing rendering=] of true:
+
+        Issue: Define this behavior. Lifecycle updates can still be triggered
+        via script APIs which query style or layout information but no visual updates
+        are presented to the user. Is this the same behavior as render-blocking?
+
+        Issue: How should input be handled when in this state? The last frame presented
+        to the user will not reflect the DOM state as it asynchronously switches to
+        the new version.
+
+        Note: The aim is to prevent unintended DOM updates from being presented to the
+        user after a cached snapshot for the elements has been captured. We wait for
+        one rendering opportunity after prepare to present DOM mutations made by the
+        author before prepare to be presented to the user. This is also the content
+        captured in snapshots.
+
+    Note: These steps will be added to the [=update the rendering=] in the HTML spec.
+        As such, the prose style is written to match other steps in that algorithm.
+</div>
+
 ## [=Perform pending transition operations=] ## {#perform-pending-transition-operations-algorithm}
 
 <div algorithm>
     To <dfn>perform pending transition operations</dfn> given a {{Document}} |document|,
         perform the following steps:
 
-    1. If |document|'s [=document/pending same document transition outgoing capture=] is not null, then:
+    1. If |document|'s [=document/active DOM transition=] is not null, then:
 
-        1. [=Perform an outgoing capture=] with |document|'s [=document/pending same document transition outgoing capture=].
+        1. If |document|'s [=document/active DOM transition=]'s [=DOMTransition/phase=] is "`pending-capture`", then [=perform an outgoing capture=] with |document|'s [=document/active DOM transition=].
 
-        1. Set |document|'s [=document/pending same document transition outgoing capture=] to null.
-
-    1. If |document|'s [=document/running same document transition=] is not null,
-        then [=update transition DOM=] for |document|'s [=document/running same document transition=].
+        1. Otherwise, if |document|'s [=document/active DOM transition=]'s [=DOMTransition/phase=] is "`animating`", then [=update transition DOM=] for |document|'s [=document/active DOM transition=].
 </div>
 
 ## [=Perform an outgoing capture=] ## {#perform-an-outgoing-capture-algorithm}
@@ -541,23 +625,7 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 
         1. Set |taggedElements|[|transitionTag|] to |capture|.
 
-    1. Set [=document/transition suppressing rendering=] to |transition|.
-
-    1. Suppress rendering opportunities for |transition|'s [=relevant global object's=] [=associated document=].
-
-        Note: The aim is to prevent unintended DOM updates from being presented to the
-        user after a cached snapshot for the elements has been captured. We wait for
-        one rendering opportunity after prepare to present DOM mutations made by the
-        author before prepare to be presented to the user. This is also the content
-        captured in snapshots.
-
-        Issue: Further clarify this behavior. Lifecycle updates can still be triggered
-        via script APIs which query style or layout information but no visual updates
-        are presented to the user. Is this the same behavior as render-blocking?
-
-        Issue: How should input be handled when in this state? The last frame presented
-        to the user will not reflect the DOM state as it asynchronously switches to
-        the new version.
+    1. Set |document|'s [=document/transition suppressing rendering=] to true.
 
     1. [=Queue a global task=] on the [=DOM manipulation task source=],
         given |transition|'s [=relevant global object=],
@@ -566,25 +634,29 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
             Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
                 although the render steps in the HTML spec act as if it's synchronous.
 
-        1. If |transition| has [=DOMTransition/concluded=], then abort these steps.
+        1. If |transition|'s [=DOMTransition/phase=] is "`done`", then abort these steps.
 
             Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
-        1. [=Call the DOM change callback=] of |transition|.
+        1. [=Call the DOM update callback=] of |transition|.
 
         1. [=promise/React=] to |transition|'s [=DOMTransition/DOM updated promise=]:
 
-            * If the promise does not settle within an implementation-defined timeout, then [=skip the page transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+            * If the promise does not settle within an implementation-defined timeout, then:
 
-            * If the promise was fulfilled, then:
-
-                1. If |transition| has [=DOMTransition/concluded=], then return.
+                1. If |transition|'s [=DOMTransition/phase=] is "`done`", then return.
 
                     Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
-                1. Set [=document/transition suppressing rendering=] to null.
+                1. [=Skip the page transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
-                1. Stop suppressing rendering opportunities for |transition|'s Document.
+            * If the promise was fulfilled, then:
+
+                1. If |transition|'s [=DOMTransition/phase=] is "`done`", then return.
+
+                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
+
+                1. Set [=document/transition suppressing rendering=] to false.
 
                 1. Set |usedTransitionTags| to a new [=/set=].
 
@@ -635,67 +707,11 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 
             * If the promise was rejected with reason |r|, then:
 
-                1. If |transition| has [=DOMTransition/concluded=], then return.
+                1. If |transition|'s [=DOMTransition/phase=] is "`done`", then return.
 
                     Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
 
                 1. [=Skip the page transition=] |transition| with |r|.
-</div>
-
-<div class=example>
-    If the default animations for the page transition are acceptable,
-    then kicking off a transition
-    requires nothing more than setting 'page-transition-tag' in the page's CSS,
-    and a single line of script to start it:
-
-    <pre highlight=js>
-    new DOMTransition()
-      .start(()=>coolFramework.changeTheDOMToPageB());
-    </pre>
-
-    If more precise management is needed, however,
-    transition elements can be managed in script:
-
-    <pre highlight=js>
-    async function doTransition() {
-      let transition = new DOMTransition();
-
-      // Specify "outgoing" elements. The tag is used to match against
-      // "incoming" elements they should transition to, and to refer to
-      // the transitioning pseudo-element.
-      document.querySelector(".old-message").style.pageTransitionTag = "message";
-
-      // The prepare() call freezes the page's rendering, and triggers
-      // an async operation to capture snapshots for the offered elements.
-      await transition.prepare(async () => {
-        // This callback is invoked by the browser when "outgoing"
-        // capture  finishes and the DOM can be switched to the new
-        // state. No frames are rendered until this callback returns.
-
-        // Asynchronously load the new page.
-        await coolFramework.changeTheDOMToPageB();
-
-        // Tagging elements during the .start() callback marks them as
-        // "incoming", to be matched up with the same-tagged "outgoing"
-        // elements marked previously and transitioned between.
-        document.querySelector(".new-message").style.pageTransitionTag = "message";
-      });
-
-      // When the promise returned by prepare() resolves, all pseudo-elements
-      // for this transition have been generated. They can now be accessed
-      // in script to set up custom animations.
-      document.documentElement.animate(
-        keyframes,
-        {...animationOptions,
-         pseudoElement: "::page-transition-container(message)",
-        }
-      );
-
-      // When the finished promise resolves, that means the transition is
-      // finished (either completed successfully or abandoned).
-      await transition.finished;
-    }
-    </pre>
 </div>
 
 ## Skip the page transition ## {#skip-the-page-transition-algorithm}
@@ -703,24 +719,17 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 <div algorithm>
     To <dfn>skip the page transition</dfn> for {{DOMTransition}} |transition| with reason |reason|:
 
-    1. [=Assert=]: |transition| has not [=DOMTransition/concluded=].
-
-    1. If |transition|'s [=DOMTransition/DOM change callback called=] is false, then [=call the DOM change callback=] of |transition|.
-
     1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-    1. If |document|'s [=document/pending same document transition outgoing capture=] is |transition|,
-        then set |document|'s [=document/pending same document transition outgoing capture=] to null.
+    1. [=Assert=]: |document|'s [=document/active DOM transition=] is |transition|.
 
-    1. If |document|'s [=document/transition suppressing rendering=] is |transition|, then:
+    1. [=Assert=]: |transition|'s [=DOMTransition/phase=] is not "`done`".
 
-        1. Stop suppressing rendering opportunities, if suppressed, for |document|.
+    1. If |transition|'s [=DOMTransition/phase=] is [=phases/before=] "`dom-update-callback-called`", then [=call the DOM update callback=] of |transition|.
 
-            Issue: "suppressing rendering opportunities" needs to be linked/defined.
+    1. Set [=document/transition suppressing rendering=] to false.
 
-        1. Set |document|'s [=document/transition suppressing rendering=] to null.
-
-    1. If |document|'s [=document/running same document transition=] is |transition|, then:
+    1. If |transition|'s [=DOMTransition/phase=] is equal to or [=phases/after=] "`animating`", then:
 
         1. Remove all associated [=page-transition pseudo-elements=] from |document|.
 
@@ -728,9 +737,9 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 
             Issue: There needs to be a definition/link for "associated".
 
-        1. Set |document|'s [=document/running same document transition=] to null.
+    1. Set |transition|'s [=DOMTransition/phase=] to "`done`".
 
-    1. Set |transition|'s [=DOMTransition/concluded=] to true.
+    1. Set |document|'s [=document/active DOM transition=] to null.
 
     1. [=Reject=] |transition|'s [=DOMTransition/ready promise=] with |reason|.
 
@@ -788,7 +797,7 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 
         Issue: There needs to be a definition/link for "active animation".
 
-        1. Set |transition|'s [=DOMTransition/concluded=] to true.
+        1. Set |transition|'s [=DOMTransition/phase=] to "`done`".
 
         1. Remove all associated [=page-transition pseudo-elements=] from |document|.
 
@@ -796,7 +805,7 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 
             Issue: There needs to be a definition/link for "associated".
 
-        1. Set |document|'s [=document/running same document transition=] to null.
+        1. Set |document|'s [=document/active DOM transition=] to null.
 
         1. [=Resolve=] |transition|'s[=DOMTransition/finished promise=].
 
@@ -905,11 +914,8 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
                 }
             </code></pre>
 
-    1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-    1. [=Assert=]: |document|'s [=document/running same document transition=] is null.
-
-    1. Set |document|'s [=document/running same document transition=] to |transition|.
+    1. Set |transition|'s [=DOMTransition/phase=] to "`animating`".
 
     Issue: How are keyframes scoped to user-agent origin? We could decide
         scope based on whether `animation-name` in the computed style
@@ -998,13 +1004,13 @@ The {{DOMTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=DOM
 </div>
 
 <div algorithm>
-    To <dfn>call the DOM change callback</dfn> of a {{DOMTransition}} |transition|:
+    To <dfn>call the DOM update callback</dfn> of a {{DOMTransition}} |transition|:
 
-    1. [=Assert=]: |transition|'s [=DOMTransition/DOM change callback called=] is false.
+    1. [=Assert=]: |transition|'s [=DOMTransition/phase=] is [=phases/before=] "`dom-update-callback-called`".
 
-    1. Let |callbackPromise| be the result of [=/invoking=] |transition|'s [=DOMTransition/DOM change callback=].
+    1. Let |callbackPromise| be the result of [=/invoking=] |transition|'s [=DOMTransition/DOM update callback=].
 
-    1. Set |transition|'s [=DOMTransition/DOM change callback called=] to true.
+    1. Set |transition|'s [=DOMTransition/phase=] to "`dom-update-callback-called`".
 
     1. [=promise/React=] to |callbackPromise|:
 

--- a/css-shared-element-transitions/index.html
+++ b/css-shared-element-transitions/index.html
@@ -9,7 +9,7 @@
   <meta content="Bikeshed version 44af0bf3e, updated Fri Jul 29 17:05:16 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/css-shared-element-transitions/" rel="canonical">
   <link href="https://drafts.csswg.org/csslogo.ico" rel="icon">
-  <meta content="fb06ecc647825a6554296cb5d2e496562170b36a" name="document-revision">
+  <meta content="64f799e850ae0e22541bdb5644e42a3864f51deb" name="document-revision">
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -1106,7 +1106,7 @@ layer elements has filters and effects coming from the root element’s style?</
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></dfn> {
-    <a data-link-type="idl-name" href="#callbackdef-updatedomcallback" id="ref-for-callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="UpdateDOMCallback " id="dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></dfn>;
+    <c- b>required</c-> <a data-link-type="idl-name" href="#callbackdef-updatedomcallback" id="ref-for-callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="UpdateDOMCallback " id="dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></dfn>;
 };
 
 <c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
@@ -2514,7 +2514,7 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></a> {
-    <a data-link-type="idl-name" href="#callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <a data-type="UpdateDOMCallback " href="#dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></a>;
+    <c- b>required</c-> <a data-link-type="idl-name" href="#callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <a data-type="UpdateDOMCallback " href="#dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></a>;
 };
 
 <c- b>callback</c-> <a href="#callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();

--- a/css-shared-element-transitions/index.html
+++ b/css-shared-element-transitions/index.html
@@ -9,7 +9,7 @@
   <meta content="Bikeshed version 44af0bf3e, updated Fri Jul 29 17:05:16 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/css-shared-element-transitions/" rel="canonical">
   <link href="https://drafts.csswg.org/csslogo.ico" rel="icon">
-  <meta content="64f799e850ae0e22541bdb5644e42a3864f51deb" name="document-revision">
+  <meta content="6c3d1532a691cdd3411beb46a36eb46cd02ed019" name="document-revision">
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -1107,9 +1107,15 @@ layer elements has filters and effects coming from the root element’s style?</
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></dfn> {
     <c- b>required</c-> <a data-link-type="idl-name" href="#callbackdef-updatedomcallback" id="ref-for-callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="UpdateDOMCallback " id="dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></dfn>;
+    <a data-link-type="idl-name" href="#enumdef-reducedmotionhandling" id="ref-for-enumdef-reducedmotionhandling"><c- n>ReducedMotionHandling</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;auto&quot;" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="ReducedMotionHandling " id="dom-domtransitioninit-reducedmotionhandling"><code><c- g>reducedMotionHandling</c-></code></dfn> = "auto";
 };
 
 <c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-reducedmotionhandling"><code><c- g>ReducedMotionHandling</c-></code></dfn> {
+    <dfn class="dfn-paneled idl-code" data-dfn-for="ReducedMotionHandling" data-dfn-type="enum-value" data-export id="dom-reducedmotionhandling-auto"><code><c- s>"auto"</c-></code></dfn>,
+    <dfn class="idl-code" data-dfn-for="ReducedMotionHandling" data-dfn-type="enum-value" data-export id="dom-reducedmotionhandling-manual"><code><c- s>"manual"</c-></code><a class="self-link" href="#dom-reducedmotionhandling-manual"></a></dfn>,
+};
 </pre>
    <h4 class="heading settled" data-level="6.1.1" id="DOMTransition-prepare"><span class="secno">6.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition①">createTransition()</a></code></span><a class="self-link" href="#DOMTransition-prepare"></a></h4>
    <div class="algorithm" data-algorithm="createTransition(init)" data-algorithm-for="Document">
@@ -1125,7 +1131,10 @@ layer elements has filters and effects coming from the root element’s style?</
       <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition">active DOM transition</a> is not null, then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition">skip the page transition</a> <var>document</var>’s <span id="ref-for-document-active-dom-transition①">active DOM transition</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant Realm</a>.</p>
       <p class="note" role="note"><span>Note:</span> This can result in two asynchronous <a data-link-type="dfn" href="#domtransition-dom-update-callback" id="ref-for-domtransition-dom-update-callback①">DOM update callbacks</a> running concurrently. One for the <var>document</var>’s current <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition②">active DOM transition</a>, and another for this <var>transition</var>. As per the <a href="#transitions-as-enhancements">design of this feature</a>, it’s assumed that the developer is using another feature or framework to correctly schedule these DOM changes.</p>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition③">active DOM transition</a> to <var>transition</var>.</p>
+      <p>If <var>init</var>[<code class="idl"><a data-link-type="idl" href="#dom-domtransitioninit-reducedmotionhandling" id="ref-for-dom-domtransitioninit-reducedmotionhandling">reducedMotionHandling</a></code>] is <code class="idl"><a data-link-type="idl" href="#dom-reducedmotionhandling-auto" id="ref-for-dom-reducedmotionhandling-auto">"auto"</a></code>, and the user has requested the system minimize the amount of non-essential motion it uses, such that the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-reduced-motion" id="ref-for-descdef-media-prefers-reduced-motion">prefers-reduced-motion</a> <a data-link-type="dfn" href="https://drafts.csswg.org/mediaqueries-5/#media-query" id="ref-for-media-query">media query</a> would match <span class="css">reduce</span>, then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
+      <p class="issue" id="issue-c763db8c"><a class="self-link" href="#issue-c763db8c"></a> It feels like there should be a better way to handle this than going via media queries. Perhaps we should centralize the definition of requesting the system for reduced motion.</p>
+     <li data-md>
+      <p>Otherwise, set <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition③">active DOM transition</a> to <var>transition</var>.</p>
       <p class="note" role="note"><span>Note:</span> The process continues in <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture">perform an outgoing capture</a>.</p>
      <li data-md>
       <p>Return <var>transition</var>.</p>
@@ -1221,26 +1230,26 @@ Initially a new <span id="ref-for-ordered-map①">map</span>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-ready-promise">ready promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-updated-promise">DOM updated promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-finished-promise">finished promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑥">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a>.</p>
    </dl>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-finished" id="ref-for-dom-domtransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise">finished promise</a>.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-ready" id="ref-for-dom-domtransition-ready">ready</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps①">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise">ready promise</a>.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-domupdated" id="ref-for-dom-domtransition-domupdated">domUpdated</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps②">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this’s</a> <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise">DOM updated promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-finished" id="ref-for-dom-domtransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise">finished promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-ready" id="ref-for-dom-domtransition-ready">ready</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps①">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this’s</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise">ready promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-domupdated" id="ref-for-dom-domtransition-domupdated">domUpdated</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps②">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this’s</a> <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise">DOM updated promise</a>.</p>
    <h4 class="heading settled" data-level="6.2.1" id="DOMTransition-skipTransition"><span class="secno">6.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition①">skipTransition()</a></code></span><a class="self-link" href="#DOMTransition-skipTransition"></a></h4>
    <div class="algorithm" data-algorithm="skipTransition()" data-algorithm-for="DOMTransition">
      The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps①">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="method" data-export id="dom-domtransition-skiptransition"><code>skipTransition()</code></dfn> are: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a>'s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase">phase</a> is not "<code>done</code>",
-then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①">skip the page transition</a> for <span id="ref-for-this①⓪">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a>'s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase">phase</a> is not "<code>done</code>",
+then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition②">skip the page transition</a> for <span id="ref-for-this①①">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
@@ -1322,7 +1331,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
          <li data-md>
           <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root①">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation">fragmentation</a>.</p>
         </ul>
-        <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition②">skip the page transition</a> for <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code> in <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a>,
+        <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition③">skip the page transition</a> for <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code> in <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑥">relevant Realm</a>,
     and return.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
@@ -1371,7 +1380,7 @@ to execute the following steps:</p>
       <ol>
        <li data-md>
         <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase③">phase</a> is "<code>done</code>", then abort these steps.</p>
-        <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition③">skipped</a> before this point.</p>
+        <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition④">skipped</a> before this point.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="#call-the-dom-update-callback" id="ref-for-call-the-dom-update-callback">Call the DOM update callback</a> of <var>transition</var>.</p>
        <li data-md>
@@ -1382,16 +1391,16 @@ to execute the following steps:</p>
           <ol>
            <li data-md>
             <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase④">phase</a> is "<code>done</code>", then return.</p>
-            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition④">skipped</a> before this point.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑤">skipped</a> before this point.</p>
            <li data-md>
-            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑤">Skip the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
+            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑥">Skip the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>.</p>
           </ol>
          <li data-md>
           <p>If the promise was fulfilled, then:</p>
           <ol>
            <li data-md>
             <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑤">phase</a> is "<code>done</code>", then return.</p>
-            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑥">skipped</a> before this point.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑦">skipped</a> before this point.</p>
            <li data-md>
             <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering②">transition suppressing rendering</a> to false.</p>
            <li data-md>
@@ -1418,7 +1427,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
                <li data-md>
                 <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root③">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation①">fragmentation</a>.</p>
               </ul>
-              <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑦">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>,
+              <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑧">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>,
     and return.</p>
              <li data-md>
               <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
@@ -1445,9 +1454,9 @@ then set <var>taggedElements</var>[<var>transitionTag</var>] to a new <a data-li
           <ol>
            <li data-md>
             <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑥">phase</a> is "<code>done</code>", then return.</p>
-            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑧">skipped</a> before this point.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑨">skipped</a> before this point.</p>
            <li data-md>
-            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑨">Skip the page transition</a> <var>transition</var> with <var>r</var>.</p>
+            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①⓪">Skip the page transition</a> <var>transition</var> with <var>r</var>.</p>
           </ol>
         </ul>
       </ol>
@@ -1846,6 +1855,7 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <li><a href="#document-active-dom-transition">active DOM transition</a><span>, in § 5.4</span>
    <li><a href="#phases-after">after</a><span>, in § 5.1</span>
    <li><a href="#animate-a-page-transition">animate a page transition</a><span>, in § 7.8</span>
+   <li><a href="#dom-reducedmotionhandling-auto">"auto"</a><span>, in § 6.1</span>
    <li><a href="#phases-before">before</a><span>, in § 5.1</span>
    <li><a href="#call-the-dom-update-callback">call the DOM update callback</a><span>, in § 7.9</span>
    <li><a href="#captured-element">captured element</a><span>, in § 5.3</span>
@@ -1864,6 +1874,7 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <li><a href="#dom-domtransition-finished">finished</a><span>, in § 6.2</span>
    <li><a href="#domtransition-finished-promise">finished promise</a><span>, in § 6.2</span>
    <li><a href="#captured-element-incoming-element">incoming element</a><span>, in § 5.3</span>
+   <li><a href="#dom-reducedmotionhandling-manual">"manual"</a><span>, in § 6.1</span>
    <li><a href="#valdef-page-transition-tag-none">none</a><span>, in § 3.1</span>
    <li><a href="#captured-element-outgoing-image">outgoing image</a><span>, in § 5.3</span>
    <li><a href="#captured-element-outgoing-styles">outgoing styles</a><span>, in § 5.3</span>
@@ -1883,6 +1894,8 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <li><a href="#typedef-pt-tag-selector">&lt;pt-tag-selector></a><span>, in § 4</span>
    <li><a href="#dom-domtransition-ready">ready</a><span>, in § 6.2</span>
    <li><a href="#domtransition-ready-promise">ready promise</a><span>, in § 6.2</span>
+   <li><a href="#enumdef-reducedmotionhandling">ReducedMotionHandling</a><span>, in § 6.1</span>
+   <li><a href="#dom-domtransitioninit-reducedmotionhandling">reducedMotionHandling</a><span>, in § 6.1</span>
    <li><a href="#skip-the-page-transition">skip the page transition</a><span>, in § 7.4</span>
    <li><a href="#dom-domtransition-skiptransition">skipTransition()</a><span>, in § 6.2.1</span>
    <li><a href="#domtransition-tagged-elements">tagged elements</a><span>, in § 6.2</span>
@@ -2100,9 +2113,9 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-relevant-realm">6.1.1. createTransition()</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
-    <li><a href="#ref-for-concept-relevant-realm②">6.2. The DOMTransition interface</a> <a href="#ref-for-concept-relevant-realm③">(2)</a> <a href="#ref-for-concept-relevant-realm④">(3)</a>
-    <li><a href="#ref-for-concept-relevant-realm⑤">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-concept-relevant-realm">6.1.1. createTransition()</a> <a href="#ref-for-concept-relevant-realm①">(2)</a> <a href="#ref-for-concept-relevant-realm②">(3)</a>
+    <li><a href="#ref-for-concept-relevant-realm③">6.2. The DOMTransition interface</a> <a href="#ref-for-concept-relevant-realm④">(2)</a> <a href="#ref-for-concept-relevant-realm⑤">(3)</a>
+    <li><a href="#ref-for-concept-relevant-realm⑥">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-update-the-rendering">
@@ -2168,6 +2181,18 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
     <li><a href="#ref-for-struct">5.3. Captured elements</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-media-query">
+   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-media-query">6.1.1. createTransition()</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-descdef-media-prefers-reduced-motion">
+   <a href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-reduced-motion">https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-reduced-motion</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-media-prefers-reduced-motion">6.1.1. createTransition()</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-x">
    <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
@@ -2196,16 +2221,16 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-aborterror">
    <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-aborterror">6.1.1. createTransition()</a>
-    <li><a href="#ref-for-aborterror①">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-aborterror">6.1.1. createTransition()</a> <a href="#ref-for-aborterror①">(2)</a>
+    <li><a href="#ref-for-aborterror②">6.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMException">
    <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMException">6.1.1. createTransition()</a>
-    <li><a href="#ref-for-idl-DOMException①">6.2.1. skipTransition()</a>
-    <li><a href="#ref-for-idl-DOMException②">7.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException③">(2)</a> <a href="#ref-for-idl-DOMException④">(3)</a>
+    <li><a href="#ref-for-idl-DOMException">6.1.1. createTransition()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
+    <li><a href="#ref-for-idl-DOMException②">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-idl-DOMException③">7.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException④">(2)</a> <a href="#ref-for-idl-DOMException⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
@@ -2283,9 +2308,9 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-this">
    <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-this">6.1.1. createTransition()</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
-    <li><a href="#ref-for-this③">6.2. The DOMTransition interface</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a> <a href="#ref-for-this⑥">(4)</a> <a href="#ref-for-this⑦">(5)</a> <a href="#ref-for-this⑧">(6)</a>
-    <li><a href="#ref-for-this⑨">6.2.1. skipTransition()</a> <a href="#ref-for-this①⓪">(2)</a>
+    <li><a href="#ref-for-this">6.1.1. createTransition()</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a>
+    <li><a href="#ref-for-this④">6.2. The DOMTransition interface</a> <a href="#ref-for-this⑤">(2)</a> <a href="#ref-for-this⑥">(3)</a> <a href="#ref-for-this⑦">(4)</a> <a href="#ref-for-this⑧">(5)</a> <a href="#ref-for-this⑨">(6)</a>
+    <li><a href="#ref-for-this①⓪">6.2.1. skipTransition()</a> <a href="#ref-for-this①①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
@@ -2404,6 +2429,12 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
      <li><span class="dfn-paneled" id="term-for-struct">struct</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[MEDIAQUERIES-5]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-media-query">media query</span>
+     <li><span class="dfn-paneled" id="term-for-descdef-media-prefers-reduced-motion">prefers-reduced-motion</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[SELECTORS-3]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-x">*</span>
@@ -2472,6 +2503,8 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-mediaqueries-5">[MEDIAQUERIES-5]
+   <dd>Dean Jackson; et al. <a href="https://drafts.csswg.org/mediaqueries-5/"><cite>Media Queries Level 5</cite></a>. URL: <a href="https://drafts.csswg.org/mediaqueries-5/">https://drafts.csswg.org/mediaqueries-5/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-selectors-3">[SELECTORS-3]
@@ -2515,9 +2548,15 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
 
 <c- b>dictionary</c-> <a href="#dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></a> {
     <c- b>required</c-> <a data-link-type="idl-name" href="#callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <a data-type="UpdateDOMCallback " href="#dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></a>;
+    <a data-link-type="idl-name" href="#enumdef-reducedmotionhandling"><c- n>ReducedMotionHandling</c-></a> <a data-default="&quot;auto&quot;" data-type="ReducedMotionHandling " href="#dom-domtransitioninit-reducedmotionhandling"><code><c- g>reducedMotionHandling</c-></code></a> = "auto";
 };
 
 <c- b>callback</c-> <a href="#callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();
+
+<c- b>enum</c-> <a href="#enumdef-reducedmotionhandling"><code><c- g>ReducedMotionHandling</c-></code></a> {
+    <a href="#dom-reducedmotionhandling-auto"><code><c- s>"auto"</c-></code></a>,
+    <a href="#dom-reducedmotionhandling-manual"><code><c- s>"manual"</c-></code></a>,
+};
 
 <c- b>interface</c-> <a href="#domtransition"><code><c- g>DOMTransition</c-></code></a> {
     <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-domtransition-skiptransition"><c- g>skipTransition</c-></a>();
@@ -2542,6 +2581,7 @@ layer elements has filters and effects coming from the root element’s style? <
    <div class="issue"> The type of "image" needs to be linked or defined. <a class="issue-return" href="#issue-4e3c66a5" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "a set of styles" needs to be linked or defined. <a class="issue-return" href="#issue-ae4536a8" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "element" needs to be linked or defined. <a class="issue-return" href="#issue-e6615d56" title="Jump to section">↵</a></div>
+   <div class="issue"> It feels like there should be a better way to handle this than going via media queries. Perhaps we should centralize the definition of requesting the system for reduced motion. <a class="issue-return" href="#issue-c763db8c" title="Jump to section">↵</a></div>
    <div class="issue"> Define this behavior. Lifecycle updates can still be triggered
 via script APIs which query style or layout information but no visual updates
 are presented to the user. Is this the same behavior as render-blocking? <a class="issue-return" href="#issue-ac37ca1e" title="Jump to section">↵</a></div>
@@ -2724,11 +2764,29 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
     <li><a href="#ref-for-dom-domtransitioninit-updatedom①">6.1.1. createTransition()</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-domtransitioninit-reducedmotionhandling">
+   <b><a href="#dom-domtransitioninit-reducedmotionhandling">#dom-domtransitioninit-reducedmotionhandling</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-domtransitioninit-reducedmotionhandling">6.1.1. createTransition()</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="callbackdef-updatedomcallback">
    <b><a href="#callbackdef-updatedomcallback">#callbackdef-updatedomcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-updatedomcallback">6.1. Additions to Document</a>
     <li><a href="#ref-for-callbackdef-updatedomcallback①">6.2. The DOMTransition interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-reducedmotionhandling">
+   <b><a href="#enumdef-reducedmotionhandling">#enumdef-reducedmotionhandling</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-reducedmotionhandling">6.1. Additions to Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-reducedmotionhandling-auto">
+   <b><a href="#dom-reducedmotionhandling-auto">#dom-reducedmotionhandling-auto</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-reducedmotionhandling-auto">6.1.1. createTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-document-createtransition">
@@ -2847,9 +2905,9 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
   <aside class="dfn-panel" data-for="skip-the-page-transition">
    <b><a href="#skip-the-page-transition">#skip-the-page-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-skip-the-page-transition">6.1.1. createTransition()</a>
-    <li><a href="#ref-for-skip-the-page-transition①">6.2.1. skipTransition()</a>
-    <li><a href="#ref-for-skip-the-page-transition②">7.3. Perform an outgoing capture</a> <a href="#ref-for-skip-the-page-transition③">(2)</a> <a href="#ref-for-skip-the-page-transition④">(3)</a> <a href="#ref-for-skip-the-page-transition⑤">(4)</a> <a href="#ref-for-skip-the-page-transition⑥">(5)</a> <a href="#ref-for-skip-the-page-transition⑦">(6)</a> <a href="#ref-for-skip-the-page-transition⑧">(7)</a> <a href="#ref-for-skip-the-page-transition⑨">(8)</a>
+    <li><a href="#ref-for-skip-the-page-transition">6.1.1. createTransition()</a> <a href="#ref-for-skip-the-page-transition①">(2)</a>
+    <li><a href="#ref-for-skip-the-page-transition②">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-skip-the-page-transition③">7.3. Perform an outgoing capture</a> <a href="#ref-for-skip-the-page-transition④">(2)</a> <a href="#ref-for-skip-the-page-transition⑤">(3)</a> <a href="#ref-for-skip-the-page-transition⑥">(4)</a> <a href="#ref-for-skip-the-page-transition⑦">(5)</a> <a href="#ref-for-skip-the-page-transition⑧">(6)</a> <a href="#ref-for-skip-the-page-transition⑨">(7)</a> <a href="#ref-for-skip-the-page-transition①⓪">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="capture-the-image">

--- a/css-shared-element-transitions/index.html
+++ b/css-shared-element-transitions/index.html
@@ -9,7 +9,7 @@
   <meta content="Bikeshed version 44af0bf3e, updated Fri Jul 29 17:05:16 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/css-shared-element-transitions/" rel="canonical">
   <link href="https://drafts.csswg.org/csslogo.ico" rel="icon">
-  <meta content="16b2061f7f601aa5747c312fd13717a259d3086f" name="document-revision">
+  <meta content="e8f3cb988b9d7b105191126097f87189cbaa5e56" name="document-revision">
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -813,10 +813,14 @@ on screen, on paper, etc.
      <a href="#api"><span class="secno">5</span> <span class="content">API</span></a>
      <ol class="toc">
       <li>
-       <a href="#the-samedocumenttransition-interface"><span class="secno">5.1</span> <span class="content">The <code class="idl"><span>SameDocumentTransition</span></code> interface</span></a>
+       <a href="#additions-to-document-api"><span class="secno">5.1</span> <span class="content">Additions to <code class="idl"><span>Document</span></code></span></a>
        <ol class="toc">
-        <li><a href="#SameDocumentTransition-prepare"><span class="secno">5.1.1</span> <span class="content"><code class="idl"><span>prepare()</span></code></span></a>
-        <li><a href="#SameDocumentTransition-abandon"><span class="secno">5.1.2</span> <span class="content"><code class="idl"><span>abandon()</span></code></span></a>
+        <li><a href="#DOMTransition-prepare"><span class="secno">5.1.1</span> <span class="content"><code class="idl"><span>createTransition()</span></code></span></a>
+       </ol>
+      <li>
+       <a href="#the-domtransition-interface"><span class="secno">5.2</span> <span class="content">The <code class="idl"><span>DOMTransition</span></code> interface</span></a>
+       <ol class="toc">
+        <li><a href="#DOMTransition-skipTransition"><span class="secno">5.2.1</span> <span class="content"><code class="idl"><span>skipTransition()</span></code></span></a>
        </ol>
      </ol>
     <li>
@@ -825,7 +829,7 @@ on screen, on paper, etc.
       <li><a href="#monkey-patch-to-rendering-algorithm"><span class="secno">6.1</span> <span class="content">Monkey patch to rendering</span></a>
       <li><a href="#perform-pending-transition-operations-algorithm"><span class="secno">6.2</span> <span class="content"><span>Perform pending transition operations</span></span></a>
       <li><a href="#perform-an-outgoing-capture-algorithm"><span class="secno">6.3</span> <span class="content"><span>Perform an outgoing capture</span></span></a>
-      <li><a href="#abandon-the-page-transition-algorithm"><span class="secno">6.4</span> <span class="content">Abandon the page transition</span></a>
+      <li><a href="#skip-the-page-transition-algorithm"><span class="secno">6.4</span> <span class="content">Skip the page transition</span></a>
       <li><a href="#capture-the-image-algorithm"><span class="secno">6.5</span> <span class="content"><span>Capture the image</span></span></a>
       <li><a href="#update-transition-dom-algorithm"><span class="secno">6.6</span> <span class="content"><span>Update transition DOM</span></span></a>
       <li><a href="#compute-the-interest-rectangle-algorithm"><span class="secno">6.7</span> <span class="content"><span>Compute the interest rectangle</span></span></a>
@@ -1039,8 +1043,6 @@ except it deals with the incoming element instead.</p>
    </dl>
    <p>The precise tree structure, and in particular the order of sibling
 pseudo-elements, is defined in the <a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements">Create transition pseudo-elements</a> algorithm.</p>
-   <p>Styles applied to these pseudo-elements are limited to styles in the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua⑨">user-agent origin</a> unless the <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase">phase</a> associated with them is
-set to "running".</p>
    <h2 class="heading settled" data-level="4" id="concepts"><span class="secno">4. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="page-transition-stacking-layer"><span class="secno">4.1. </span><span class="content">The <a data-link-type="dfn" href="#page-transition-layer" id="ref-for-page-transition-layer">page-transition layer</a> stacking layer</span><a class="self-link" href="#page-transition-stacking-layer"></a></h3>
    <p>This specification introduces a stacking layer to the <a href="https://www.w3.org/TR/CSS2/zindex.html">Elaborate description of Stacking Contexts</a>.</p>
@@ -1083,84 +1085,104 @@ layer elements has filters and effects coming from the root element’s style?</
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition">SameDocumentTransition</a></code> or null. Initially null.</p>
+     <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition">DOMTransition</a></code> or null. Initially null.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-running-same-document-transition">running same document transition</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition①">SameDocumentTransition</a></code> or null. Initially null.</p>
+     <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①">DOMTransition</a></code> or null. Initially null.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-transition-suppressing-rendering">transition suppressing rendering</dfn>
+    <dd data-md>
+     <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition②">DOMTransition</a></code> or null. Initially null.</p>
    </dl>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
-   <h3 class="heading settled" data-level="5.1" id="the-samedocumenttransition-interface"><span class="secno">5.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition②">SameDocumentTransition</a></code> interface</span><a class="self-link" href="#the-samedocumenttransition-interface"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="samedocumenttransition"><code><c- g>SameDocumentTransition</c-></code></dfn> {
-    <dfn class="idl-code" data-dfn-for="SameDocumentTransition" data-dfn-type="constructor" data-export data-lt="SameDocumentTransition()|constructor()" id="dom-samedocumenttransition-samedocumenttransition"><code><c- g>constructor</c-></code><a class="self-link" href="#dom-samedocumenttransition-samedocumenttransition"></a></dfn>();
-    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-samedocumenttransition-prepare" id="ref-for-dom-samedocumenttransition-prepare"><c- g>prepare</c-></a>(<a data-link-type="idl-name" href="#callbackdef-preparecallback" id="ref-for-callbackdef-preparecallback"><c- n>PrepareCallback</c-></a> <dfn class="idl-code" data-dfn-for="SameDocumentTransition/prepare(cb)" data-dfn-type="argument" data-export id="dom-samedocumenttransition-prepare-cb-cb"><code><c- g>cb</c-></code><a class="self-link" href="#dom-samedocumenttransition-prepare-cb-cb"></a></dfn>);
-    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-samedocumenttransition-abandon" id="ref-for-dom-samedocumenttransition-abandon"><c- g>abandon</c-></a>();
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined②"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SameDocumentTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-samedocumenttransition-finished"><code><c- g>finished</c-></code></dfn>;
+   <h3 class="heading settled" data-level="5.1" id="additions-to-document-api"><span class="secno">5.1. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code></span><a class="self-link" href="#additions-to-document-api"></a></h3>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- g>Document</c-></a> {
+    <a data-link-type="idl-name" href="#domtransition" id="ref-for-domtransition③"><c- n>DOMTransition</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition"><c- g>createTransition</c-></a>(<a data-link-type="idl-name" href="#dictdef-domtransitioninit" id="ref-for-dictdef-domtransitioninit"><c- n>DOMTransitionInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createTransition(init)" data-dfn-type="argument" data-export id="dom-document-createtransition-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-document-createtransition-init-init"></a></dfn>);
 };
 
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-preparecallback"><code><c- g>PrepareCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></dfn> {
+    <a data-link-type="idl-name" href="#callbackdef-changedomcallback" id="ref-for-callbackdef-changedomcallback"><c- n>ChangeDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="ChangeDOMCallback " id="dom-domtransitioninit-changedom"><code><c- g>changeDOM</c-></code></dfn>;
+};
+
+<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-changedomcallback"><code><c- g>ChangeDOMCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
 </pre>
-   <div class="note" role="note"> The <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition③">SameDocumentTransition</a></code> represents and controls
+   <h4 class="heading settled" data-level="5.1.1" id="DOMTransition-prepare"><span class="secno">5.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition①">createTransition()</a></code></span><a class="self-link" href="#DOMTransition-prepare"></a></h4>
+   <div class="algorithm" data-algorithm="createTransition(init)" data-algorithm-for="Document">
+     The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export id="dom-document-createtransition"><code>createTransition(<var>init</var>)</code></dfn> are as follows: 
+    <ol>
+     <li data-md>
+      <p>Let <var>transition</var> be a new <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition④">DOMTransition</a></code> object in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
+     <li data-md>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback" id="ref-for-domtransition-dom-change-callback">DOM change callback</a> to <var>init</var>[<code class="idl"><a data-link-type="idl" href="#dom-domtransitioninit-changedom" id="ref-for-dom-domtransitioninit-changedom">changeDOM</a></code>].</p>
+     <li data-md>
+      <p>Let <var>document</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated document</a>.</p>
+     <li data-md>
+      <p>Let <var>transitionsToSkip</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of every <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑤">DOMTransition</a></code> within <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant Realm</a>,
+that has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded">concluded</a>,
+and is not <var>transition</var>.</p>
+     <li data-md>
+      <p class="assertion">Assert: The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> of <var>transitionsToSkip</var> is 0 or 1.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>transitionToSkip</var> of <var>transitionsToSkip</var>, <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition">skip the page transition</a> <var>transitionToSkip</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</a> is null.</p>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture①">pending same document transition outgoing capture</a> to <var>transition</var>.</p>
+      <p class="note" role="note"><span>Note:</span> This process continues in <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture">perform an outgoing capture</a>.</p>
+     <li data-md>
+      <p>Return <var>transition</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="5.2" id="the-domtransition-interface"><span class="secno">5.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑥">DOMTransition</a></code> interface</span><a class="self-link" href="#the-domtransition-interface"></a></h3>
+<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="domtransition"><code><c- g>DOMTransition</c-></code></dfn> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition"><c- g>skipTransition</c-></a>();
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-domtransition-finished"><code><c- g>finished</c-></code></dfn>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined②"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-domtransition-ready"><code><c- g>ready</c-></code></dfn>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-domtransition-domupdated"><code><c- g>domUpdated</c-></code></dfn>;
+};
+</pre>
+   <div class="note" role="note"> The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑦">DOMTransition</a></code> represents and controls
     a single same-document transition. That is, it controls a transition where the
     starting and ending document are the same, possibly with changes to the
     document’s DOM structure. </div>
-   <p><code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition④">SameDocumentTransition</a></code> objects have the following:</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑧">DOMTransition</a></code> has the following:</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="SameDocumentTransition" data-dfn-type="dfn" data-noexport id="samedocumenttransition-tagged-elements">tagged elements</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-tagged-elements">tagged elements</dfn>
     <dd data-md>
      <p>a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>,
 whose keys are <a data-link-type="dfn" href="#page-transition-tag" id="ref-for-page-transition-tag">page transition tags</a> and whose values are <a data-link-type="dfn" href="#captured-element" id="ref-for-captured-element①">captured elements</a>.
 Initially a new <span id="ref-for-ordered-map①">map</span>.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="SameDocumentTransition" data-dfn-type="dfn" data-noexport id="samedocumenttransition-phase">phase</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-concluded">concluded</dfn>
     <dd data-md>
-     <p>"<code>idle</code>", "<code>preparing</code>", "<code>running</code>", or "<code>finished</code>".
-Initially "<code>idle</code>".</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="SameDocumentTransition" data-dfn-type="dfn" data-noexport id="samedocumenttransition-prepare-callback">prepare callback</dfn>
+     <p>a boolean. Initially false.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-change-callback">DOM change callback</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#callbackdef-preparecallback" id="ref-for-callbackdef-preparecallback①">PrepareCallback</a></code> or null. Initially null.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="SameDocumentTransition" data-dfn-type="dfn" data-noexport id="samedocumenttransition-ready-promise">ready promise</dfn>
+     <p>a <code class="idl"><a data-link-type="idl" href="#callbackdef-changedomcallback" id="ref-for-callbackdef-changedomcallback①">ChangeDOMCallback</a></code> or null. Initially null.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-change-callback-called">DOM change callback called</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="SameDocumentTransition" data-dfn-type="dfn" data-noexport id="samedocumenttransition-finished-promise">finished promise</dfn>
+     <p>a boolean. Initially false.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-ready-promise">ready promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a>.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-updated-promise">DOM updated promise</dfn>
+    <dd data-md>
+     <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code>.
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a>.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-finished-promise">finished promise</dfn>
+    <dd data-md>
+     <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑥">Promise</a></code>.
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a>.</p>
    </dl>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-samedocumenttransition-finished" id="ref-for-dom-samedocumenttransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-finished-promise" id="ref-for-samedocumenttransition-finished-promise">finished promise</a>.</p>
-   <h4 class="heading settled" data-level="5.1.1" id="SameDocumentTransition-prepare"><span class="secno">5.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-samedocumenttransition-prepare" id="ref-for-dom-samedocumenttransition-prepare①">prepare()</a></code></span><a class="self-link" href="#SameDocumentTransition-prepare"></a></h4>
-   <div class="algorithm" data-algorithm="SameDocumentTransition.prepare()">
-     The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="SameDocumentTransition" data-dfn-type="method" data-export id="dom-samedocumenttransition-prepare"><code>prepare(<var>cb</var>)</code></dfn> are as follows: 
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-finished" id="ref-for-dom-domtransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise">finished promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-ready" id="ref-for-dom-domtransition-ready">ready</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps①">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this’s</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise">ready promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-domupdated" id="ref-for-dom-domtransition-domupdated">domUpdated</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps②">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this’s</a> <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise">DOM updated promise</a>.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="DOMTransition-skipTransition"><span class="secno">5.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition①">skipTransition()</a></code></span><a class="self-link" href="#DOMTransition-skipTransition"></a></h4>
+   <div class="algorithm" data-algorithm="skipTransition()" data-algorithm-for="DOMTransition">
+     The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps①">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="method" data-export id="dom-domtransition-skiptransition"><code>skipTransition()</code></dfn> are: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase①">phase</a> is not "<code>idle</code>", then throw an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
-     <li data-md>
-      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase②">phase</a> to "<code>preparing</code>".</p>
-     <li data-md>
-      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-prepare-callback" id="ref-for-samedocumenttransition-prepare-callback">prepare callback</a> to <var>cb</var>.</p>
-     <li data-md>
-      <p>Let <var>document</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated document</a>.</p>
-     <li data-md>
-      <p>Let <var>transitionsToAbandon</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of every <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition⑤">SameDocumentTransition</a></code> within <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a> that has a <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase③">phase</a> that is not "<code>idle</code>".</p>
-      <p class="issue" id="issue-a5efd1d7"><a class="self-link" href="#issue-a5efd1d7"></a> The ordering needs to be defined, probably in a queue.</p>
-     <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>transition</var> of <var>transitionsToAbandon</var>, <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition">abandon the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
-      <p class="issue" id="issue-a8028177"><a class="self-link" href="#issue-a8028177"></a> The callbacks may still be running after this, which may not be what we want.</p>
-     <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</a> is null.</p>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture①">pending same document transition outgoing capture</a> to <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a>.</p>
-     <li data-md>
-      <p>Return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-ready-promise" id="ref-for-samedocumenttransition-ready-promise">ready promise</a>.</p>
-    </ol>
-    <p class="note" role="note"><span>Note:</span> This process continues in <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture">perform an outgoing capture</a>.</p>
-   </div>
-   <h4 class="heading settled" data-level="5.1.2" id="SameDocumentTransition-abandon"><span class="secno">5.1.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-samedocumenttransition-abandon" id="ref-for-dom-samedocumenttransition-abandon①">abandon()</a></code></span><a class="self-link" href="#SameDocumentTransition-abandon"></a></h4>
-   <div class="algorithm" data-algorithm="abandon()" data-algorithm-for="SameDocumentTransition">
-     The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps①">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="SameDocumentTransition" data-dfn-type="method" data-export id="dom-samedocumenttransition-abandon"><code>abandon()</code></dfn> are: 
-    <ol>
-     <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this’s</a> <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase④">phase</a> is not "<code>finished</code>",
-then <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition①">abandon the page transition</a> <span id="ref-for-this①①">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a> has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded①">concluded</a>,
+then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①">skip the page transition</a> for <span id="ref-for-this①①">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="6" id="algorithms"><span class="secno">6. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
@@ -1169,14 +1191,14 @@ then <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-aba
      Run the following steps before <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:mark-paint-timing">marking paint timing</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering">update the rendering</a> steps: 
     <ol>
      <li data-md>
-      <p>For each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active" id="ref-for-fully-active">fully active</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> in <var>docs</var>, <a data-link-type="dfn" href="#perform-pending-transition-operations" id="ref-for-perform-pending-transition-operations">perform pending transition operations</a> for that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>.</p>
+      <p>For each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active" id="ref-for-fully-active">fully active</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> in <var>docs</var>, <a data-link-type="dfn" href="#perform-pending-transition-operations" id="ref-for-perform-pending-transition-operations">perform pending transition operations</a> for that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>.</p>
     </ol>
     <p class="note" role="note"><span>Note:</span> These steps will be added to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering①">update the rendering</a> in the HTML spec.
         As such, the prose style is written to match other steps in that algorithm.</p>
    </div>
    <h3 class="heading settled" data-level="6.2" id="perform-pending-transition-operations-algorithm"><span class="secno">6.2. </span><span class="content"><a data-link-type="dfn" href="#perform-pending-transition-operations" id="ref-for-perform-pending-transition-operations①">Perform pending transition operations</a></span><a class="self-link" href="#perform-pending-transition-operations-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="perform pending transition operations">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-pending-transition-operations">perform pending transition operations</dfn> given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> <var>document</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-pending-transition-operations">perform pending transition operations</dfn> given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <var>document</var>,
         perform the following steps: 
     <ol>
      <li data-md>
@@ -1194,15 +1216,13 @@ then <a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-tr
    </div>
    <h3 class="heading settled" data-level="6.3" id="perform-an-outgoing-capture-algorithm"><span class="secno">6.3. </span><span class="content"><a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture②">Perform an outgoing capture</a></span><a class="self-link" href="#perform-an-outgoing-capture-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="perform an outgoing capture">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-an-outgoing-capture">perform an outgoing capture</dfn> given a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition⑥">SameDocumentTransition</a></code> <var>transition</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-an-outgoing-capture">perform an outgoing capture</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑨">DOMTransition</a></code> <var>transition</var>,
         perform the following steps: 
     <ol>
      <li data-md>
-      <p>Let <var>taggedElements</var> be <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-tagged-elements" id="ref-for-samedocumenttransition-tagged-elements">tagged elements</a>.</p>
+      <p>Let <var>taggedElements</var> be <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-tagged-elements" id="ref-for-domtransition-tagged-elements">tagged elements</a>.</p>
      <li data-md>
       <p>Let <var>usedTransitionTags</var> be a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of strings.</p>
-     <li data-md>
-      <p>Let <var>preparationFailed</var> be false.</p>
      <li data-md>
       <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window①">associated document</a>.</p>
      <li data-md>
@@ -1227,7 +1247,8 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
          <li data-md>
           <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root①">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation">fragmentation</a>.</p>
         </ul>
-        <p>Then set <var>preparationFailed</var> to true and <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>.</p>
+        <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition②">skip the page transition</a> for <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code> in <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑥">relevant Realm</a>,
+    and return.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
        <li data-md>
@@ -1265,6 +1286,8 @@ will cause the view box to coincide with <var>element</var>’s <a data-link-typ
         <p>Set <var>taggedElements</var>[<var>transitionTag</var>] to <var>capture</var>.</p>
       </ol>
      <li data-md>
+      <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering">transition suppressing rendering</a> to <var>transition</var>.</p>
+     <li data-md>
       <p>Suppress rendering opportunities for <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window②">associated document</a>.</p>
       <p class="note" role="note"><span>Note:</span> The aim is to prevent unintended DOM updates from being presented to the
 user after a cached snapshot for the elements has been captured. We wait for
@@ -1285,36 +1308,25 @@ to execute the following steps:</p>
         although the render steps in the HTML spec act as if it’s synchronous.</p>
       <ol>
        <li data-md>
-        <p>Let <var>timedOut</var> be false.</p>
+        <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded②">concluded</a>, then abort these steps.</p>
+        <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition③">skipped</a> before this point.</p>
        <li data-md>
-        <p>Let <var>userP</var> be the result of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#invoke-a-callback-function" id="ref-for-invoke-a-callback-function">invoking</a> <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-prepare-callback" id="ref-for-samedocumenttransition-prepare-callback①">prepare callback</a>.</p>
+        <p><a data-link-type="dfn" href="#call-the-dom-change-callback" id="ref-for-call-the-dom-change-callback">Call the DOM change callback</a> of <var>transition</var>.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled" id="ref-for-dfn-perform-steps-once-promise-is-settled">React</a> to <var>userP</var>:</p>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled" id="ref-for-dfn-perform-steps-once-promise-is-settled">React</a> to <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise①">DOM updated promise</a>:</p>
         <ul>
          <li data-md>
-          <p>If <var>userP</var> does not settle within an implementation-defined timeout, then:</p>
-          <ol>
-           <li data-md>
-            <p>Set <var>timedOut</var> to true.</p>
-           <li data-md>
-            <p>If <var>preparationFailed</var> is true,
-then <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition②">abandon the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror②">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>,
-and abort these steps.</p>
-           <li data-md>
-            <p>Otherwise, <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition③">abandon the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>.</p>
-          </ol>
+          <p>If the promise does not settle within an implementation-defined timeout, then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition④">skip the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
          <li data-md>
-          <p>If <var>userP</var> was fulfilled, then:</p>
+          <p>If the promise was fulfilled, then:</p>
           <ol>
            <li data-md>
-            <p>If <var>timedOut</var> is true, then return.</p>
+            <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded③">concluded</a>, then return.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑤">skipped</a> before this point.</p>
+           <li data-md>
+            <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering①">transition suppressing rendering</a> to null.</p>
            <li data-md>
             <p>Stop suppressing rendering opportunities for <var>transition</var>’s Document.</p>
-            <p class="note" role="note"><span>Note:</span> Resuming rendering opportunities is delayed until fulfillment of <var>userP</var> to allow asynchronous loading of the incoming DOM.</p>
-           <li data-md>
-            <p>If <var>preparationFailed</var> is true,
-then <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition④">abandon the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror③">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>,
-and return.</p>
            <li data-md>
             <p>Set <var>usedTransitionTags</var> to a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>.</p>
            <li data-md>
@@ -1339,7 +1351,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
                <li data-md>
                 <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root③">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation①">fragmentation</a>.</p>
               </ul>
-              <p>Then <a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition⑤">abandon the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>,
+              <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑥">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>,
     and return.</p>
              <li data-md>
               <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
@@ -1352,8 +1364,6 @@ then set <var>taggedElements</var>[<var>transitionTag</var>] to a new <a data-li
               <p>Let <var>capture</var>’s <a data-link-type="dfn" href="#captured-element-incoming-element" id="ref-for-captured-element-incoming-element">incoming element</a> item be <var>element</var>.</p>
             </ol>
            <li data-md>
-            <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase⑤">phase</a> "<code>running</code>".</p>
-           <li data-md>
             <p><a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements①">Create transition pseudo-elements</a> for <var>transition</var>.</p>
            <li data-md>
             <p><a data-link-type="dfn" href="#animate-a-page-transition" id="ref-for-animate-a-page-transition②">Animate a page transition</a> <var>transition</var>.</p>
@@ -1361,35 +1371,33 @@ then set <var>taggedElements</var>[<var>transitionTag</var>] to a new <a data-li
     to compute information calculated during style/layout.</p>
             <p class="note" role="note"><span>Note:</span> The frame-by-frame parts of the animation are handled in <a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom①">update transition DOM</a>.</p>
            <li data-md>
-            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">Resolve</a> <a data-link-type="dfn" href="#samedocumenttransition-ready-promise" id="ref-for-samedocumenttransition-ready-promise①">ready promise</a>.</p>
+            <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">Resolve</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise①">ready promise</a>.</p>
           </ol>
          <li data-md>
-          <p>If <var>userP</var> was rejected with reason <var>r</var>, then:</p>
+          <p>If the promise was rejected with reason <var>r</var>, then:</p>
           <ol>
            <li data-md>
-            <p>If <var>timedOut</var> is true, then return.</p>
+            <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded④">concluded</a>, then return.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑦">skipped</a> before this point.</p>
            <li data-md>
-            <p>Let <var>reason</var> be an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror④">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code> if <var>preparationFailed</var> is true,
-otherwise <var>r</var>.</p>
-           <li data-md>
-            <p><a data-link-type="dfn" href="#abandon-the-page-transition" id="ref-for-abandon-the-page-transition⑥">Abandon the page transition</a> <var>transition</var> with <var>reason</var>.</p>
+            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑧">Skip the page transition</a> <var>transition</var> with <var>r</var>.</p>
           </ol>
         </ul>
       </ol>
     </ol>
    </div>
-   <div class="example" id="example-70320d4b">
-    <a class="self-link" href="#example-70320d4b"></a> If the default animations for the page transition are acceptable,
+   <div class="example" id="example-6af13d7b">
+    <a class="self-link" href="#example-6af13d7b"></a> If the default animations for the page transition are acceptable,
     then kicking off a transition
     requires nothing more than setting <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag④">page-transition-tag</a> in the page’s CSS,
     and a single line of script to start it: 
-<pre class="highlight"><c- ow>new</c-> SameDocumentTransition<c- p>()</c->
+<pre class="highlight"><c- ow>new</c-> DOMTransition<c- p>()</c->
   <c- p>.</c->start<c- p>(()=></c->coolFramework<c- p>.</c->changeTheDOMToPageB<c- p>());</c->
 </pre>
     <p>If more precise management is needed, however,
     transition elements can be managed in script:</p>
 <pre class="highlight"><c- k>async</c-> <c- a>function</c-> doTransition<c- p>()</c-> <c- p>{</c->
-  <c- a>let</c-> transition <c- o>=</c-> <c- ow>new</c-> SameDocumentTransition<c- p>();</c->
+  <c- a>let</c-> transition <c- o>=</c-> <c- ow>new</c-> DOMTransition<c- p>();</c->
 
   <c- c1>// Specify "outgoing" elements. The tag is used to match against</c->
   <c- c1>// "incoming" elements they should transition to, and to refer to</c->
@@ -1428,35 +1436,44 @@ otherwise <var>r</var>.</p>
 <c- p>}</c->
 </pre>
    </div>
-   <h3 class="heading settled" data-level="6.4" id="abandon-the-page-transition-algorithm"><span class="secno">6.4. </span><span class="content">Abandon the page transition</span><a class="self-link" href="#abandon-the-page-transition-algorithm"></a></h3>
-   <div class="algorithm" data-algorithm="abandon the page transition">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="abandon-the-page-transition">abandon the page transition</dfn> for <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition⑦">SameDocumentTransition</a></code> <var>transition</var> with <var>error</var>: 
+   <h3 class="heading settled" data-level="6.4" id="skip-the-page-transition-algorithm"><span class="secno">6.4. </span><span class="content">Skip the page transition</span><a class="self-link" href="#skip-the-page-transition-algorithm"></a></h3>
+   <div class="algorithm" data-algorithm="skip the page transition">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="skip-the-page-transition">skip the page transition</dfn> for <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①⓪">DOMTransition</a></code> <var>transition</var> with reason <var>reason</var>: 
     <ol>
      <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>transition</var> has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑤">concluded</a>.</p>
+     <li data-md>
+      <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called">DOM change callback called</a> is false, then <a data-link-type="dfn" href="#call-the-dom-change-callback" id="ref-for-call-the-dom-change-callback①">call the DOM change callback</a> of <var>transition</var>.</p>
+     <li data-md>
       <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global④">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window③">associated document</a>.</p>
-     <li data-md>
-      <p>If <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase⑥">phase</a> is not "<code>idle</code>", then:</p>
-      <ol>
-       <li data-md>
-        <p>Stop suppressing rendering opportunities <var>document</var>, if currently suppressed.</p>
-        <p class="issue" id="issue-2b1a73c3"><a class="self-link" href="#issue-2b1a73c3"></a> "suppressing rendering opportunities" needs to be linked/defined.</p>
-       <li data-md>
-        <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements④">page-transition pseudo-elements</a> from <var>document</var>.</p>
-        <p class="issue" id="issue-80506344"><a class="self-link" href="#issue-80506344"></a> There needs to be a definition/link for "remove".</p>
-        <p class="issue" id="issue-cc250ace"><a class="self-link" href="#issue-cc250ace"></a> There needs to be a definition/link for "associated".</p>
-      </ol>
-     <li data-md>
-      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase⑦">phase</a> to "<code>finished</code>".</p>
      <li data-md>
       <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture⑤">pending same document transition outgoing capture</a> is <var>transition</var>,
 then set <var>document</var>’s <span id="ref-for-document-pending-same-document-transition-outgoing-capture⑥">pending same document transition outgoing capture</span> to null.</p>
      <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition②">running same document transition</a> is <var>transition</var>,
-then set <var>document</var>’s <span id="ref-for-document-running-same-document-transition③">running same document transition</span> to null.</p>
+      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering②">transition suppressing rendering</a> is <var>transition</var>, then:</p>
+      <ol>
+       <li data-md>
+        <p>Stop suppressing rendering opportunities, if suppressed, for <var>document</var>.</p>
+        <p class="issue" id="issue-2b1a73c3"><a class="self-link" href="#issue-2b1a73c3"></a> "suppressing rendering opportunities" needs to be linked/defined.</p>
+       <li data-md>
+        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering③">transition suppressing rendering</a> to null.</p>
+      </ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-ready-promise" id="ref-for-samedocumenttransition-ready-promise②">ready promise</a> with <var>error</var>.</p>
+      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition②">running same document transition</a> is <var>transition</var>, then:</p>
+      <ol>
+       <li data-md>
+        <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements④">page-transition pseudo-elements</a> from <var>document</var>.</p>
+        <p class="issue" id="issue-80506344"><a class="self-link" href="#issue-80506344"></a> There needs to be a definition/link for "remove".</p>
+        <p class="issue" id="issue-cc250ace"><a class="self-link" href="#issue-cc250ace"></a> There needs to be a definition/link for "associated".</p>
+       <li data-md>
+        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition③">running same document transition</a> to null.</p>
+      </ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-finished-promise" id="ref-for-samedocumenttransition-finished-promise①">finished promise</a> with <var>error</var>.</p>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑥">concluded</a> to true.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise②">ready promise</a> with <var>reason</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise①">finished promise</a> with <var>reason</var>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="6.5" id="capture-the-image-algorithm"><span class="secno">6.5. </span><span class="content"><a data-link-type="dfn" href="#capture-the-image" id="ref-for-capture-the-image②">Capture the image</a></span><a class="self-link" href="#capture-the-image-algorithm"></a></h3>
@@ -1494,33 +1511,38 @@ The natural size of the image is equal to the <var>interestRectangle</var> bound
    </div>
    <h3 class="heading settled" data-level="6.6" id="update-transition-dom-algorithm"><span class="secno">6.6. </span><span class="content"><a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom②">Update transition DOM</a></span><a class="self-link" href="#update-transition-dom-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="update transition DOM">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="update-transition-dom">update transition DOM</dfn> given a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition⑧">SameDocumentTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="update-transition-dom">update transition DOM</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①①">DOMTransition</a></code> <var>transition</var>: 
     <ol>
+     <li data-md>
+      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑤">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window④">associated document</a>.</p>
      <li data-md>
       <p>For each <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑤">page-transition pseudo-elements</a> associated with <var>transition</var>,
 check whether there is an active animation associated with this pseudo-element.</p>
       <p class="issue" id="issue-9b6c2555"><a class="self-link" href="#issue-9b6c2555"></a> Define what active animation means here.</p>
      <li data-md>
       <p>If no <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑥">page-transition pseudo-elements</a> has an active animation:</p>
+      <p class="issue" id="issue-7108de0e"><a class="self-link" href="#issue-7108de0e"></a> There needs to be a definition/link for "active animation".</p>
       <ol>
        <li data-md>
-        <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-phase" id="ref-for-samedocumenttransition-phase⑧">phase</a> to "<code>finished</code>".</p>
+        <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑦">concluded</a> to true.</p>
        <li data-md>
-        <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑦">page-transition pseudo-elements</a> from <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window④">associated document</a>.</p>
-       <li data-md>
-        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">Resolve</a> <var>transition</var>’s<a data-link-type="dfn" href="#samedocumenttransition-finished-promise" id="ref-for-samedocumenttransition-finished-promise②">finished promise</a>.</p>
+        <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑦">page-transition pseudo-elements</a> from <var>document</var>.</p>
         <p class="issue" id="issue-80506344①"><a class="self-link" href="#issue-80506344①"></a> There needs to be a definition/link for "remove".</p>
         <p class="issue" id="issue-cc250ace①"><a class="self-link" href="#issue-cc250ace①"></a> There needs to be a definition/link for "associated".</p>
+       <li data-md>
+        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition④">running same document transition</a> to null.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">Resolve</a> <var>transition</var>’s<a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise②">finished promise</a>.</p>
        <li data-md>
         <p>Return.</p>
       </ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>tag</var> -> <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-tagged-elements" id="ref-for-samedocumenttransition-tagged-elements①">tagged elements</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>tag</var> -> <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-tagged-elements" id="ref-for-domtransition-tagged-elements①">tagged elements</a>:</p>
       <ol>
        <li data-md>
         <p>If <var>capturedElement</var> has an "incoming element", run <a data-link-type="dfn" href="#capture-the-image" id="ref-for-capture-the-image③">capture the image</a> on <var>capturedElement</var>’s "incoming element" and update the displayed
 image for <span class="css">::page-transition-incoming-image</span> with the tag <var>tag</var>.</p>
-        <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⓪">user-agent origin</a>,
+        <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua⑨">user-agent origin</a>,
 set <var>incoming</var>’s <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-images-4/#propdef-object-view-box" id="ref-for-propdef-object-view-box②">object-view-box</a> property
 to a value that when applied to <var>incoming</var>,
 will cause the view box to coincide with "incoming element"'s <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-4/#border-box" id="ref-for-border-box③">border box</a> in the image.</p>
@@ -1551,22 +1573,22 @@ then return a rectangle that is equal to <var>el</var>’s <a data-link-type="df
    </div>
    <h3 class="heading settled" data-level="6.8" id="animate-a-page-transition-algorithm"><span class="secno">6.8. </span><span class="content"><a data-link-type="dfn" href="#animate-a-page-transition" id="ref-for-animate-a-page-transition③">Animate a page transition</a></span><a class="self-link" href="#animate-a-page-transition-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="animate a page transition">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="animate-a-page-transition">animate a page transition</dfn> given a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition⑨">SameDocumentTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="animate-a-page-transition">animate a page transition</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①②">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
-      <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-fade-out" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①①">user-agent origin</a> as follows:</p>
+      <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-fade-out" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⓪">user-agent origin</a> as follows:</p>
 <pre><code class="highlight"><c- n>@keyframes</c-> page-transition-fade-out <c- p>{</c->
       to <c- p>{</c-> <c- k>opacity</c-><c- p>:</c-> <c- m>0</c-><c- p>;</c-> <c- p>}</c->
 <c- p>}</c->
 </code></pre>
      <li data-md>
-      <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-fade-in" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①②">user-agent origin</a> as follows:</p>
+      <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-fade-in" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①①">user-agent origin</a> as follows:</p>
 <pre><code class="highlight"><c- n>@keyframes</c-> page-transition-fade-in <c- p>{</c->
       from <c- p>{</c-> <c- k>opacity</c-><c- p>:</c-> <c- m>0</c-><c- p>;</c-> <c- p>}</c->
 <c- p>}</c->
 </code></pre>
      <li data-md>
-      <p>Apply the following styles in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①③">user-agent origin</a>:</p>
+      <p>Apply the following styles in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①②">user-agent origin</a>:</p>
 <pre><code class="highlight"><c- k>html</c-><c- p>:</c-><c- nf>:page-transition-outgoing-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>{</c->
     <c- k>animation-name</c-><c- p>:</c-> page-transition-fade-out<c- p>;</c->
 <c- p>}</c->
@@ -1576,7 +1598,7 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
 <c- p>}</c->
 </code></pre>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate①">For each</a> <var>tag</var> -> <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-tagged-elements" id="ref-for-samedocumenttransition-tagged-elements②">tagged elements</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate①">For each</a> <var>tag</var> -> <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-tagged-elements" id="ref-for-domtransition-tagged-elements②">tagged elements</a>:</p>
       <ol>
        <li data-md>
         <p>If neither of <var>capturedElement</var>’s <a data-link-type="dfn" href="#captured-element-outgoing-image" id="ref-for-captured-element-outgoing-image①">outgoing image</a> or <a data-link-type="dfn" href="#captured-element-incoming-element" id="ref-for-captured-element-incoming-element①">incoming element</a> is null:</p>
@@ -1588,7 +1610,7 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
          <li data-md>
           <p>Let <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-sizing-3/#propdef-height" id="ref-for-propdef-height②">height</a> be <var>capturedElement</var>’s <a data-link-type="dfn" href="#captured-element-outgoing-styles" id="ref-for-captured-element-outgoing-styles③">outgoing styles</a>'s <span class="property" id="ref-for-propdef-height③">height</span> property.</p>
          <li data-md>
-          <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-container-anim-<var>tag</var>" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①④">user-agent origin</a> as follows:</p>
+          <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-container-anim-<var>tag</var>" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①③">user-agent origin</a> as follows:</p>
         </ol>
 <pre><code class="highlight"><c- n>@keyframes</c-> page-transition-container-anim-|tag| <c- p>{</c->
     from <c- p>{</c->
@@ -1599,18 +1621,18 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
 <c- p>}</c->
 </code></pre>
        <li data-md>
-        <p>Apply the following styles in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑤">user-agent origin</a>:</p>
+        <p>Apply the following styles in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①④">user-agent origin</a>:</p>
 <pre><code class="highlight"><c- k>html</c-><c- p>:</c-><c- nf>:page-transition-container</c-><c- p>(</c->|tag|<c- p>)</c-> <c- p>{</c->
     <c- k>animation-name</c-><c- p>:</c-> page-transition-container-anim-|tag|<c- p>;</c->
 <c- p>}</c->
 </code></pre>
       </ol>
      <li data-md>
-      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑤">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window⑤">associated document</a>.</p>
+      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑥">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window⑤">associated document</a>.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition④">running same document transition</a> is null.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition⑤">running same document transition</a> is null.</p>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition⑤">running same document transition</a> to <var>transition</var>.</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition⑥">running same document transition</a> to <var>transition</var>.</p>
     </ol>
     <p class="issue" id="issue-4306640b"><a class="self-link" href="#issue-4306640b"></a> How are keyframes scoped to user-agent origin? We could decide
         scope based on whether <code>animation-name</code> in the computed style
@@ -1621,12 +1643,12 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
    </div>
    <h3 class="heading settled" data-level="6.9" id="create-transition-pseudo-elements-algorithm"><span class="secno">6.9. </span><span class="content"><a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements②">Create transition pseudo-elements</a></span><a class="self-link" href="#create-transition-pseudo-elements-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="create transition pseudo-elements">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-transition-pseudo-elements">create transition pseudo-elements</dfn> for a <code class="idl"><a data-link-type="idl" href="#samedocumenttransition" id="ref-for-samedocumenttransition①⓪">SameDocumentTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-transition-pseudo-elements">create transition pseudo-elements</dfn> for a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①③">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
       <p>Let <var>transitionRoot</var> be the result of creating a new <a class="css" data-link-type="maybe" href="#selectordef-page-transition" id="ref-for-selectordef-page-transition③">::page-transition</a> pseudo-element.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate②">For each</a> <var>transitionTag</var> → <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#samedocumenttransition-tagged-elements" id="ref-for-samedocumenttransition-tagged-elements③">tagged elements</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate②">For each</a> <var>transitionTag</var> → <var>capturedElement</var> of <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-tagged-elements" id="ref-for-domtransition-tagged-elements③">tagged elements</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>container</var> be the result of creating a new <span class="css">::page-transition-container</span> pseudo-element with the tag <var>transitionTag</var>.</p>
@@ -1666,7 +1688,7 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
           <p>Set <var>direction</var> to the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value④">computed value</a> of <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction" id="ref-for-propdef-direction③">direction</a> on <var>capturedElement</var>’s <a data-link-type="dfn" href="#captured-element-incoming-element" id="ref-for-captured-element-incoming-element⑦">incoming element</a>.</p>
         </ol>
        <li data-md>
-        <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑥">user-agent origin</a>,
+        <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑤">user-agent origin</a>,
 set <var>container</var>’s <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-sizing-3/#propdef-width" id="ref-for-propdef-width⑤">width</a>, <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-sizing-3/#propdef-height" id="ref-for-propdef-height⑤">height</a>, <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform" id="ref-for-propdef-transform⑤">transform</a>, <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode" id="ref-for-propdef-writing-mode④">writing-mode</a>, and <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction" id="ref-for-propdef-direction④">direction</a> properties
 to <var>width</var>, <var>height</var>, <var>transform</var>, <var>writingMode</var>, and <var>direction</var>.</p>
        <li data-md>
@@ -1683,7 +1705,7 @@ displaying <var>capturedElement</var>’s <a data-link-type="dfn" href="#capture
          <li data-md>
           <p>Append <var>outgoing</var> to <var>imageWrapper</var>.</p>
          <li data-md>
-          <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑦">user-agent origin</a>,
+          <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑥">user-agent origin</a>,
 set <var>outgoing</var>’s <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-images-4/#propdef-object-view-box" id="ref-for-propdef-object-view-box③">object-view-box</a> property to <var>capturedElement</var>’s <a data-link-type="dfn" href="#captured-element-outgoing-styles" id="ref-for-captured-element-outgoing-styles⑨">outgoing styles</a> <span class="property" id="ref-for-propdef-object-view-box④">object-view-box</span> property.</p>
           <p class="issue" id="issue-1c3f1c0f"><a class="self-link" href="#issue-1c3f1c0f"></a> Which of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-xywh" id="ref-for-funcdef-basic-shape-xywh">xywh()</a>/<span class="css">rect()</span>/<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset" id="ref-for-funcdef-basic-shape-inset">inset()</a> should we use?</p>
         </ol>
@@ -1695,11 +1717,30 @@ set <var>outgoing</var>’s <a class="property css" data-link-type="property" hr
          <li data-md>
           <p>Append <var>incoming</var> to <var>imageWrapper</var>.</p>
          <li data-md>
-          <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑧">user-agent origin</a>,
+          <p>At the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⑦">user-agent origin</a>,
 set <var>incoming</var>’s <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-images-4/#propdef-object-view-box" id="ref-for-propdef-object-view-box⑤">object-view-box</a> property to a value that when applied to <var>incoming</var>,
 will cause the view box to coincide with <a data-link-type="dfn" href="#captured-element-incoming-element" id="ref-for-captured-element-incoming-element①⓪">incoming element</a>'s <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-4/#border-box" id="ref-for-border-box⑦">border box</a> in the image.</p>
         </ol>
       </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="call the DOM change callback">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="call-the-dom-change-callback">call the DOM change callback</dfn> of a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①④">DOMTransition</a></code> <var>transition</var>: 
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called①">DOM change callback called</a> is false.</p>
+     <li data-md>
+      <p>Let <var>callbackPromise</var> be the result of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#invoke-a-callback-function" id="ref-for-invoke-a-callback-function">invoking</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback" id="ref-for-domtransition-dom-change-callback①">DOM change callback</a>.</p>
+     <li data-md>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called②">DOM change callback called</a> to true.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled" id="ref-for-dfn-perform-steps-once-promise-is-settled①">React</a> to <var>callbackPromise</var>:</p>
+      <ul>
+       <li data-md>
+        <p>If <var>callbackPromise</var> was fulfilled, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve②">resolve</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise②">DOM updated promise</a>.</p>
+       <li data-md>
+        <p>If <var>callbackPromise</var> was rejected with reason <var>r</var>, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject②">reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise③">DOM updated promise</a> with <var>r</var>.</p>
+      </ul>
     </ol>
    </div>
   </main>
@@ -1797,19 +1838,27 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-samedocumenttransition-abandon">abandon()</a><span>, in § 5.1.2</span>
-   <li><a href="#abandon-the-page-transition">abandon the page transition</a><span>, in § 6.4</span>
    <li><a href="#animate-a-page-transition">animate a page transition</a><span>, in § 6.8</span>
+   <li><a href="#call-the-dom-change-callback">call the DOM change callback</a><span>, in § 6.9</span>
    <li><a href="#captured-element">captured element</a><span>, in § 4.2</span>
    <li><a href="#capture-the-image">capture the image</a><span>, in § 6.5</span>
    <li><a href="#capture-the-image">capturing the image</a><span>, in § 6.5</span>
+   <li><a href="#dom-domtransitioninit-changedom">changeDOM</a><span>, in § 5.1</span>
+   <li><a href="#callbackdef-changedomcallback">ChangeDOMCallback</a><span>, in § 5.1</span>
    <li><a href="#computing-the-interest-rectangle">compute the interest rectangle</a><span>, in § 6.7</span>
    <li><a href="#computing-the-interest-rectangle">computing the interest rectangle</a><span>, in § 6.7</span>
-   <li><a href="#dom-samedocumenttransition-samedocumenttransition">constructor()</a><span>, in § 5.1</span>
+   <li><a href="#domtransition-concluded">concluded</a><span>, in § 5.2</span>
+   <li><a href="#dom-document-createtransition">createTransition(init)</a><span>, in § 5.1.1</span>
    <li><a href="#create-transition-pseudo-elements">create transition pseudo-elements</a><span>, in § 6.9</span>
    <li><a href="#valdef-page-transition-tag-custom-ident">&lt;custom-ident></a><span>, in § 2.1</span>
-   <li><a href="#dom-samedocumenttransition-finished">finished</a><span>, in § 5.1</span>
-   <li><a href="#samedocumenttransition-finished-promise">finished promise</a><span>, in § 5.1</span>
+   <li><a href="#domtransition-dom-change-callback">DOM change callback</a><span>, in § 5.2</span>
+   <li><a href="#domtransition-dom-change-callback-called">DOM change callback called</a><span>, in § 5.2</span>
+   <li><a href="#domtransition">DOMTransition</a><span>, in § 5.2</span>
+   <li><a href="#dictdef-domtransitioninit">DOMTransitionInit</a><span>, in § 5.1</span>
+   <li><a href="#dom-domtransition-domupdated">domUpdated</a><span>, in § 5.2</span>
+   <li><a href="#domtransition-dom-updated-promise">DOM updated promise</a><span>, in § 5.2</span>
+   <li><a href="#dom-domtransition-finished">finished</a><span>, in § 5.2</span>
+   <li><a href="#domtransition-finished-promise">finished promise</a><span>, in § 5.2</span>
    <li><a href="#captured-element-incoming-element">incoming element</a><span>, in § 4.2</span>
    <li><a href="#valdef-page-transition-tag-none">none</a><span>, in § 2.1</span>
    <li><a href="#captured-element-outgoing-image">outgoing image</a><span>, in § 4.2</span>
@@ -1826,16 +1875,14 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <li><a href="#document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</a><span>, in § 4.3</span>
    <li><a href="#perform-an-outgoing-capture">perform an outgoing capture</a><span>, in § 6.3</span>
    <li><a href="#perform-pending-transition-operations">perform pending transition operations</a><span>, in § 6.2</span>
-   <li><a href="#samedocumenttransition-phase">phase</a><span>, in § 5.1</span>
-   <li><a href="#samedocumenttransition-prepare-callback">prepare callback</a><span>, in § 5.1</span>
-   <li><a href="#callbackdef-preparecallback">PrepareCallback</a><span>, in § 5.1</span>
-   <li><a href="#dom-samedocumenttransition-prepare">prepare(cb)</a><span>, in § 5.1.1</span>
    <li><a href="#typedef-pt-tag-selector">&lt;pt-tag-selector></a><span>, in § 3</span>
-   <li><a href="#samedocumenttransition-ready-promise">ready promise</a><span>, in § 5.1</span>
+   <li><a href="#dom-domtransition-ready">ready</a><span>, in § 5.2</span>
+   <li><a href="#domtransition-ready-promise">ready promise</a><span>, in § 5.2</span>
    <li><a href="#document-running-same-document-transition">running same document transition</a><span>, in § 4.3</span>
-   <li><a href="#samedocumenttransition">SameDocumentTransition</a><span>, in § 5.1</span>
-   <li><a href="#dom-samedocumenttransition-samedocumenttransition">SameDocumentTransition()</a><span>, in § 5.1</span>
-   <li><a href="#samedocumenttransition-tagged-elements">tagged elements</a><span>, in § 5.1</span>
+   <li><a href="#skip-the-page-transition">skip the page transition</a><span>, in § 6.4</span>
+   <li><a href="#dom-domtransition-skiptransition">skipTransition()</a><span>, in § 5.2.1</span>
+   <li><a href="#domtransition-tagged-elements">tagged elements</a><span>, in § 5.2</span>
+   <li><a href="#document-transition-suppressing-rendering">transition suppressing rendering</a><span>, in § 4.3</span>
    <li><a href="#update-transition-dom">update transition DOM</a><span>, in § 6.6</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-border-box">
@@ -1865,10 +1912,10 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">2.1. page-transition-tag</a>
-    <li><a href="#ref-for-cascade-origin-ua①">3. Pseudo-elements</a> <a href="#ref-for-cascade-origin-ua②">(2)</a> <a href="#ref-for-cascade-origin-ua③">(3)</a> <a href="#ref-for-cascade-origin-ua④">(4)</a> <a href="#ref-for-cascade-origin-ua⑤">(5)</a> <a href="#ref-for-cascade-origin-ua⑥">(6)</a> <a href="#ref-for-cascade-origin-ua⑦">(7)</a> <a href="#ref-for-cascade-origin-ua⑧">(8)</a> <a href="#ref-for-cascade-origin-ua⑨">(9)</a>
-    <li><a href="#ref-for-cascade-origin-ua①⓪">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-cascade-origin-ua①①">6.8. Animate a page transition</a> <a href="#ref-for-cascade-origin-ua①②">(2)</a> <a href="#ref-for-cascade-origin-ua①③">(3)</a> <a href="#ref-for-cascade-origin-ua①④">(4)</a> <a href="#ref-for-cascade-origin-ua①⑤">(5)</a>
-    <li><a href="#ref-for-cascade-origin-ua①⑥">6.9. Create transition pseudo-elements</a> <a href="#ref-for-cascade-origin-ua①⑦">(2)</a> <a href="#ref-for-cascade-origin-ua①⑧">(3)</a>
+    <li><a href="#ref-for-cascade-origin-ua①">3. Pseudo-elements</a> <a href="#ref-for-cascade-origin-ua②">(2)</a> <a href="#ref-for-cascade-origin-ua③">(3)</a> <a href="#ref-for-cascade-origin-ua④">(4)</a> <a href="#ref-for-cascade-origin-ua⑤">(5)</a> <a href="#ref-for-cascade-origin-ua⑥">(6)</a> <a href="#ref-for-cascade-origin-ua⑦">(7)</a> <a href="#ref-for-cascade-origin-ua⑧">(8)</a>
+    <li><a href="#ref-for-cascade-origin-ua⑨">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-cascade-origin-ua①⓪">6.8. Animate a page transition</a> <a href="#ref-for-cascade-origin-ua①①">(2)</a> <a href="#ref-for-cascade-origin-ua①②">(3)</a> <a href="#ref-for-cascade-origin-ua①③">(4)</a> <a href="#ref-for-cascade-origin-ua①④">(5)</a>
+    <li><a href="#ref-for-cascade-origin-ua①⑤">6.9. Create transition pseudo-elements</a> <a href="#ref-for-cascade-origin-ua①⑥">(2)</a> <a href="#ref-for-cascade-origin-ua①⑦">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-layout-containment">
@@ -1988,8 +2035,9 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.3. Additions to Document</a> <a href="#ref-for-document①">(2)</a>
-    <li><a href="#ref-for-document②">6.1. Monkey patch to rendering</a> <a href="#ref-for-document③">(2)</a>
-    <li><a href="#ref-for-document④">6.2. Perform pending transition operations</a>
+    <li><a href="#ref-for-document②">5.1. Additions to Document</a> <a href="#ref-for-document③">(2)</a>
+    <li><a href="#ref-for-document④">6.1. Monkey patch to rendering</a> <a href="#ref-for-document⑤">(2)</a>
+    <li><a href="#ref-for-document⑥">6.2. Perform pending transition operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-element">
@@ -2016,9 +2064,9 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-concept-document-window">
    <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-window">5.1.1. prepare()</a>
+    <li><a href="#ref-for-concept-document-window">5.1.1. createTransition()</a>
     <li><a href="#ref-for-concept-document-window①">6.3. Perform an outgoing capture</a> <a href="#ref-for-concept-document-window②">(2)</a>
-    <li><a href="#ref-for-concept-document-window③">6.4. Abandon the page transition</a>
+    <li><a href="#ref-for-concept-document-window③">6.4. Skip the page transition</a>
     <li><a href="#ref-for-concept-document-window④">6.6. Update transition DOM</a>
     <li><a href="#ref-for-concept-document-window⑤">6.8. Animate a page transition</a>
    </ul>
@@ -2038,17 +2086,19 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-relevant-global">5.1.1. prepare()</a>
+    <li><a href="#ref-for-concept-relevant-global">5.1.1. createTransition()</a>
     <li><a href="#ref-for-concept-relevant-global①">6.3. Perform an outgoing capture</a> <a href="#ref-for-concept-relevant-global②">(2)</a> <a href="#ref-for-concept-relevant-global③">(3)</a>
-    <li><a href="#ref-for-concept-relevant-global④">6.4. Abandon the page transition</a>
-    <li><a href="#ref-for-concept-relevant-global⑤">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-concept-relevant-global④">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-concept-relevant-global⑤">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-concept-relevant-global⑥">6.8. Animate a page transition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-relevant-realm">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
-    <li><a href="#ref-for-concept-relevant-realm②">5.1.1. prepare()</a>
+    <li><a href="#ref-for-concept-relevant-realm">5.1.1. createTransition()</a> <a href="#ref-for-concept-relevant-realm①">(2)</a> <a href="#ref-for-concept-relevant-realm②">(3)</a>
+    <li><a href="#ref-for-concept-relevant-realm③">5.2. The DOMTransition interface</a> <a href="#ref-for-concept-relevant-realm④">(2)</a> <a href="#ref-for-concept-relevant-realm⑤">(3)</a>
+    <li><a href="#ref-for-concept-relevant-realm⑥">6.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-update-the-rendering">
@@ -2066,14 +2116,10 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">5.1.1. prepare()</a>
-    <li><a href="#ref-for-assert①">6.8. Animate a page transition</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-iteration-break">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-assert">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-assert①">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-assert②">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-assert③">6.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-contain">
@@ -2105,19 +2151,25 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">5.1.1. prepare()</a>
+    <li><a href="#ref-for-list">5.1.1. createTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-map">
    <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ordered-map">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-ordered-map①">(2)</a>
+    <li><a href="#ref-for-ordered-map">5.2. The DOMTransition interface</a> <a href="#ref-for-ordered-map①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-set">
    <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">6.3. Perform an outgoing capture</a> <a href="#ref-for-ordered-set①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-size">
+   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-size">5.1.1. createTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-struct">
@@ -2154,30 +2206,29 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-aborterror">
    <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-aborterror">5.1.1. prepare()</a>
-    <li><a href="#ref-for-aborterror①">5.1.2. abandon()</a>
-    <li><a href="#ref-for-aborterror②">6.3. Perform an outgoing capture</a> <a href="#ref-for-aborterror③">(2)</a> <a href="#ref-for-aborterror④">(3)</a>
+    <li><a href="#ref-for-aborterror">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-aborterror①">5.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMException">
    <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMException">5.1.1. prepare()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
-    <li><a href="#ref-for-idl-DOMException②">5.1.2. abandon()</a>
-    <li><a href="#ref-for-idl-DOMException③">6.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException④">(2)</a> <a href="#ref-for-idl-DOMException⑤">(3)</a> <a href="#ref-for-idl-DOMException⑥">(4)</a> <a href="#ref-for-idl-DOMException⑦">(5)</a>
+    <li><a href="#ref-for-idl-DOMException">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-idl-DOMException①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-idl-DOMException②">6.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException③">(2)</a> <a href="#ref-for-idl-DOMException④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
    <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidstateerror">5.1.1. prepare()</a>
-    <li><a href="#ref-for-invalidstateerror①">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-invalidstateerror">6.3. Perform an outgoing capture</a> <a href="#ref-for-invalidstateerror①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
    <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-promise">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a> <a href="#ref-for-idl-promise④">(5)</a>
+    <li><a href="#ref-for-idl-promise">5.1. Additions to Document</a>
+    <li><a href="#ref-for-idl-promise①">5.2. The DOMTransition interface</a> <a href="#ref-for-idl-promise②">(2)</a> <a href="#ref-for-idl-promise③">(3)</a> <a href="#ref-for-idl-promise④">(4)</a> <a href="#ref-for-idl-promise⑤">(5)</a> <a href="#ref-for-idl-promise⑥">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-timeouterror">
@@ -2189,44 +2240,46 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <aside class="dfn-panel" data-for="term-for-a-new-promise">
    <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-a-new-promise">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-a-new-promise①">(2)</a>
+    <li><a href="#ref-for-a-new-promise">5.2. The DOMTransition interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-any">
    <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-any">5.1. The SameDocumentTransition interface</a>
+    <li><a href="#ref-for-idl-any">5.1. Additions to Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-getter-steps">
    <a href="https://webidl.spec.whatwg.org/#getter-steps">https://webidl.spec.whatwg.org/#getter-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-getter-steps">5.1. The SameDocumentTransition interface</a>
+    <li><a href="#ref-for-getter-steps">5.2. The DOMTransition interface</a> <a href="#ref-for-getter-steps①">(2)</a> <a href="#ref-for-getter-steps②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
    <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-a-callback-function">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-invoke-a-callback-function">6.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-method-steps">
    <a href="https://webidl.spec.whatwg.org/#method-steps">https://webidl.spec.whatwg.org/#method-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-method-steps">5.1.1. prepare()</a>
-    <li><a href="#ref-for-method-steps①">5.1.2. abandon()</a>
+    <li><a href="#ref-for-method-steps">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-method-steps①">5.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
    <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">6.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-reject">
    <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reject">6.4. Abandon the page transition</a> <a href="#ref-for-reject①">(2)</a>
+    <li><a href="#ref-for-reject">6.4. Skip the page transition</a> <a href="#ref-for-reject①">(2)</a>
+    <li><a href="#ref-for-reject②">6.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
@@ -2234,20 +2287,21 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    <ul>
     <li><a href="#ref-for-resolve">6.3. Perform an outgoing capture</a>
     <li><a href="#ref-for-resolve①">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-resolve②">6.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-this">
    <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-this">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
-    <li><a href="#ref-for-this③">5.1.1. prepare()</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a> <a href="#ref-for-this⑥">(4)</a> <a href="#ref-for-this⑦">(5)</a> <a href="#ref-for-this⑧">(6)</a> <a href="#ref-for-this⑨">(7)</a>
-    <li><a href="#ref-for-this①⓪">5.1.2. abandon()</a> <a href="#ref-for-this①①">(2)</a>
+    <li><a href="#ref-for-this">5.1.1. createTransition()</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a>
+    <li><a href="#ref-for-this④">5.2. The DOMTransition interface</a> <a href="#ref-for-this⑤">(2)</a> <a href="#ref-for-this⑥">(3)</a> <a href="#ref-for-this⑦">(4)</a> <a href="#ref-for-this⑧">(5)</a> <a href="#ref-for-this⑨">(6)</a>
+    <li><a href="#ref-for-this①⓪">5.2.1. skipTransition()</a> <a href="#ref-for-this①①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
    <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-undefined">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a>
+    <li><a href="#ref-for-idl-undefined">5.2. The DOMTransition interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2351,7 +2405,6 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
     <ul>
      <li><span class="dfn-paneled" id="term-for-set-append">append</span>
      <li><span class="dfn-paneled" id="term-for-assert">assert</span>
-     <li><span class="dfn-paneled" id="term-for-iteration-break">break</span>
      <li><span class="dfn-paneled" id="term-for-list-contain">contain</span>
      <li><span class="dfn-paneled" id="term-for-iteration-continue">continue</span>
      <li><span class="dfn-paneled" id="term-for-map-exists">exist</span>
@@ -2359,6 +2412,7 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
      <li><span class="dfn-paneled" id="term-for-list">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-map">map</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set">set</span>
+     <li><span class="dfn-paneled" id="term-for-list-size">size</span>
      <li><span class="dfn-paneled" id="term-for-struct">struct</span>
     </ul>
    <li>
@@ -2467,14 +2521,22 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>interface</c-> <a href="#samedocumenttransition"><code><c- g>SameDocumentTransition</c-></code></a> {
-    <a href="#dom-samedocumenttransition-samedocumenttransition"><code><c- g>constructor</c-></code></a>();
-    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-samedocumenttransition-prepare"><c- g>prepare</c-></a>(<a data-link-type="idl-name" href="#callbackdef-preparecallback"><c- n>PrepareCallback</c-></a> <a href="#dom-samedocumenttransition-prepare-cb-cb"><code><c- g>cb</c-></code></a>);
-    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-samedocumenttransition-abandon"><c- g>abandon</c-></a>();
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a data-readonly data-type="Promise<undefined>" href="#dom-samedocumenttransition-finished"><code><c- g>finished</c-></code></a>;
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document"><c- g>Document</c-></a> {
+    <a data-link-type="idl-name" href="#domtransition"><c- n>DOMTransition</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createtransition"><c- g>createTransition</c-></a>(<a data-link-type="idl-name" href="#dictdef-domtransitioninit"><c- n>DOMTransitionInit</c-></a> <a href="#dom-document-createtransition-init-init"><code><c- g>init</c-></code></a>);
 };
 
-<c- b>callback</c-> <a href="#callbackdef-preparecallback"><code><c- g>PrepareCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();
+<c- b>dictionary</c-> <a href="#dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></a> {
+    <a data-link-type="idl-name" href="#callbackdef-changedomcallback"><c- n>ChangeDOMCallback</c-></a> <a data-type="ChangeDOMCallback " href="#dom-domtransitioninit-changedom"><code><c- g>changeDOM</c-></code></a>;
+};
+
+<c- b>callback</c-> <a href="#callbackdef-changedomcallback"><code><c- g>ChangeDOMCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();
+
+<c- b>interface</c-> <a href="#domtransition"><code><c- g>DOMTransition</c-></code></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-domtransition-skiptransition"><c- g>skipTransition</c-></a>();
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a data-readonly data-type="Promise<undefined>" href="#dom-domtransition-finished"><code><c- g>finished</c-></code></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a data-readonly data-type="Promise<undefined>" href="#dom-domtransition-ready"><code><c- g>ready</c-></code></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a data-readonly data-type="Promise<undefined>" href="#dom-domtransition-domupdated"><code><c- g>domUpdated</c-></code></a>;
+};
 
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
@@ -2492,8 +2554,6 @@ layer elements has filters and effects coming from the root element’s style? <
    <div class="issue"> The type of "image" needs to be linked or defined. <a class="issue-return" href="#issue-4e3c66a5" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "a set of styles" needs to be linked or defined. <a class="issue-return" href="#issue-ae4536a8" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "element" needs to be linked or defined. <a class="issue-return" href="#issue-e6615d56" title="Jump to section">↵</a></div>
-   <div class="issue"> The ordering needs to be defined, probably in a queue. <a class="issue-return" href="#issue-a5efd1d7" title="Jump to section">↵</a></div>
-   <div class="issue"> The callbacks may still be running after this, which may not be what we want. <a class="issue-return" href="#issue-a8028177" title="Jump to section">↵</a></div>
    <div class="issue"> The link for "paint order" doesn’t seem right.
     Is there a more canonical definition? <a class="issue-return" href="#issue-ad1ca140" title="Jump to section">↵</a></div>
    <div class="issue"> This needs proper types. <a class="issue-return" href="#issue-f121180b" title="Jump to section">↵</a></div>
@@ -2510,6 +2570,7 @@ the new version. <a class="issue-return" href="#issue-f6dfdcaa" title="Jump to s
    <div class="issue"> There needs to be a definition/link for "associated". <a class="issue-return" href="#issue-cc250ace" title="Jump to section">↵</a></div>
    <div class="issue"> Refactor this so the algorithm takes a set of elements that will be captured. This centralizes the logic for deciding if an element should be included or not. <a class="issue-return" href="#issue-2bfbc0f2" title="Jump to section">↵</a></div>
    <div class="issue"> Define what active animation means here. <a class="issue-return" href="#issue-9b6c2555" title="Jump to section">↵</a></div>
+   <div class="issue"> There needs to be a definition/link for "active animation". <a class="issue-return" href="#issue-7108de0e" title="Jump to section">↵</a></div>
    <div class="issue"> There needs to be a definition/link for "remove". <a class="issue-return" href="#issue-80506344①" title="Jump to section">↵</a></div>
    <div class="issue"> There needs to be a definition/link for "associated". <a class="issue-return" href="#issue-cc250ace①" title="Jump to section">↵</a></div>
    <div class="issue"> Also clarify updating the animation based on new bounds/transform to
@@ -2544,14 +2605,14 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
   <aside class="dfn-panel" data-for="page-transition-tag">
    <b><a href="#page-transition-tag">#page-transition-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-page-transition-tag">5.1. The SameDocumentTransition interface</a>
+    <li><a href="#ref-for-page-transition-tag">5.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="page-transition-pseudo-elements">
    <b><a href="#page-transition-pseudo-elements">#page-transition-pseudo-elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-transition-pseudo-elements">3. Pseudo-elements</a> <a href="#ref-for-page-transition-pseudo-elements①">(2)</a> <a href="#ref-for-page-transition-pseudo-elements②">(3)</a> <a href="#ref-for-page-transition-pseudo-elements③">(4)</a>
-    <li><a href="#ref-for-page-transition-pseudo-elements④">6.4. Abandon the page transition</a>
+    <li><a href="#ref-for-page-transition-pseudo-elements④">6.4. Skip the page transition</a>
     <li><a href="#ref-for-page-transition-pseudo-elements⑤">6.6. Update transition DOM</a> <a href="#ref-for-page-transition-pseudo-elements⑥">(2)</a> <a href="#ref-for-page-transition-pseudo-elements⑦">(3)</a>
    </ul>
   </aside>
@@ -2597,7 +2658,7 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
    <b><a href="#captured-element">#captured-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-captured-element">4.2. Captured elements</a>
-    <li><a href="#ref-for-captured-element①">5.1. The SameDocumentTransition interface</a>
+    <li><a href="#ref-for-captured-element①">5.2. The DOMTransition interface</a>
     <li><a href="#ref-for-captured-element②">6.3. Perform an outgoing capture</a> <a href="#ref-for-captured-element③">(2)</a>
    </ul>
   </aside>
@@ -2628,99 +2689,147 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
   <aside class="dfn-panel" data-for="document-pending-same-document-transition-outgoing-capture">
    <b><a href="#document-pending-same-document-transition-outgoing-capture">#document-pending-same-document-transition-outgoing-capture</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture">5.1.1. prepare()</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture①">(2)</a>
+    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture">5.1.1. createTransition()</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture①">(2)</a>
     <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture②">6.2. Perform pending transition operations</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture③">(2)</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture④">(3)</a>
-    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑤">6.4. Abandon the page transition</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑥">(2)</a>
+    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑤">6.4. Skip the page transition</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="document-running-same-document-transition">
    <b><a href="#document-running-same-document-transition">#document-running-same-document-transition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-running-same-document-transition">6.2. Perform pending transition operations</a> <a href="#ref-for-document-running-same-document-transition①">(2)</a>
-    <li><a href="#ref-for-document-running-same-document-transition②">6.4. Abandon the page transition</a> <a href="#ref-for-document-running-same-document-transition③">(2)</a>
-    <li><a href="#ref-for-document-running-same-document-transition④">6.8. Animate a page transition</a> <a href="#ref-for-document-running-same-document-transition⑤">(2)</a>
+    <li><a href="#ref-for-document-running-same-document-transition②">6.4. Skip the page transition</a> <a href="#ref-for-document-running-same-document-transition③">(2)</a>
+    <li><a href="#ref-for-document-running-same-document-transition④">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-document-running-same-document-transition⑤">6.8. Animate a page transition</a> <a href="#ref-for-document-running-same-document-transition⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition">
-   <b><a href="#samedocumenttransition">#samedocumenttransition</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-transition-suppressing-rendering">
+   <b><a href="#document-transition-suppressing-rendering">#document-transition-suppressing-rendering</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition">4.3. Additions to Document</a> <a href="#ref-for-samedocumenttransition①">(2)</a>
-    <li><a href="#ref-for-samedocumenttransition②">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-samedocumenttransition③">(2)</a> <a href="#ref-for-samedocumenttransition④">(3)</a>
-    <li><a href="#ref-for-samedocumenttransition⑤">5.1.1. prepare()</a>
-    <li><a href="#ref-for-samedocumenttransition⑥">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-samedocumenttransition⑦">6.4. Abandon the page transition</a>
-    <li><a href="#ref-for-samedocumenttransition⑧">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-samedocumenttransition⑨">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-samedocumenttransition①⓪">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-document-transition-suppressing-rendering">6.3. Perform an outgoing capture</a> <a href="#ref-for-document-transition-suppressing-rendering①">(2)</a>
+    <li><a href="#ref-for-document-transition-suppressing-rendering②">6.4. Skip the page transition</a> <a href="#ref-for-document-transition-suppressing-rendering③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-samedocumenttransition-finished">
-   <b><a href="#dom-samedocumenttransition-finished">#dom-samedocumenttransition-finished</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dictdef-domtransitioninit">
+   <b><a href="#dictdef-domtransitioninit">#dictdef-domtransitioninit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-samedocumenttransition-finished">5.1. The SameDocumentTransition interface</a>
+    <li><a href="#ref-for-dictdef-domtransitioninit">5.1. Additions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-preparecallback">
-   <b><a href="#callbackdef-preparecallback">#callbackdef-preparecallback</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-domtransitioninit-changedom">
+   <b><a href="#dom-domtransitioninit-changedom">#dom-domtransitioninit-changedom</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-callbackdef-preparecallback">5.1. The SameDocumentTransition interface</a> <a href="#ref-for-callbackdef-preparecallback①">(2)</a>
+    <li><a href="#ref-for-dom-domtransitioninit-changedom">5.1.1. createTransition()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition-tagged-elements">
-   <b><a href="#samedocumenttransition-tagged-elements">#samedocumenttransition-tagged-elements</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="callbackdef-changedomcallback">
+   <b><a href="#callbackdef-changedomcallback">#callbackdef-changedomcallback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition-tagged-elements">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-samedocumenttransition-tagged-elements①">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-samedocumenttransition-tagged-elements②">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-samedocumenttransition-tagged-elements③">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-callbackdef-changedomcallback">5.1. Additions to Document</a>
+    <li><a href="#ref-for-callbackdef-changedomcallback①">5.2. The DOMTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition-phase">
-   <b><a href="#samedocumenttransition-phase">#samedocumenttransition-phase</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-document-createtransition">
+   <b><a href="#dom-document-createtransition">#dom-document-createtransition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition-phase">3. Pseudo-elements</a>
-    <li><a href="#ref-for-samedocumenttransition-phase①">5.1.1. prepare()</a> <a href="#ref-for-samedocumenttransition-phase②">(2)</a> <a href="#ref-for-samedocumenttransition-phase③">(3)</a>
-    <li><a href="#ref-for-samedocumenttransition-phase④">5.1.2. abandon()</a>
-    <li><a href="#ref-for-samedocumenttransition-phase⑤">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-samedocumenttransition-phase⑥">6.4. Abandon the page transition</a> <a href="#ref-for-samedocumenttransition-phase⑦">(2)</a>
-    <li><a href="#ref-for-samedocumenttransition-phase⑧">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-dom-document-createtransition">5.1. Additions to Document</a>
+    <li><a href="#ref-for-dom-document-createtransition①">5.1.1. createTransition()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition-prepare-callback">
-   <b><a href="#samedocumenttransition-prepare-callback">#samedocumenttransition-prepare-callback</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="domtransition">
+   <b><a href="#domtransition">#domtransition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition-prepare-callback">5.1.1. prepare()</a>
-    <li><a href="#ref-for-samedocumenttransition-prepare-callback①">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition">4.3. Additions to Document</a> <a href="#ref-for-domtransition①">(2)</a> <a href="#ref-for-domtransition②">(3)</a>
+    <li><a href="#ref-for-domtransition③">5.1. Additions to Document</a>
+    <li><a href="#ref-for-domtransition④">5.1.1. createTransition()</a> <a href="#ref-for-domtransition⑤">(2)</a>
+    <li><a href="#ref-for-domtransition⑥">5.2. The DOMTransition interface</a> <a href="#ref-for-domtransition⑦">(2)</a> <a href="#ref-for-domtransition⑧">(3)</a>
+    <li><a href="#ref-for-domtransition⑨">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition①⓪">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition①①">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition①②">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-domtransition①③">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition-ready-promise">
-   <b><a href="#samedocumenttransition-ready-promise">#samedocumenttransition-ready-promise</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-domtransition-finished">
+   <b><a href="#dom-domtransition-finished">#dom-domtransition-finished</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition-ready-promise">5.1.1. prepare()</a>
-    <li><a href="#ref-for-samedocumenttransition-ready-promise①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-samedocumenttransition-ready-promise②">6.4. Abandon the page transition</a>
+    <li><a href="#ref-for-dom-domtransition-finished">5.2. The DOMTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="samedocumenttransition-finished-promise">
-   <b><a href="#samedocumenttransition-finished-promise">#samedocumenttransition-finished-promise</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-domtransition-ready">
+   <b><a href="#dom-domtransition-ready">#dom-domtransition-ready</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-samedocumenttransition-finished-promise">5.1. The SameDocumentTransition interface</a>
-    <li><a href="#ref-for-samedocumenttransition-finished-promise①">6.4. Abandon the page transition</a>
-    <li><a href="#ref-for-samedocumenttransition-finished-promise②">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-dom-domtransition-ready">5.2. The DOMTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-samedocumenttransition-prepare">
-   <b><a href="#dom-samedocumenttransition-prepare">#dom-samedocumenttransition-prepare</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-domtransition-domupdated">
+   <b><a href="#dom-domtransition-domupdated">#dom-domtransition-domupdated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-samedocumenttransition-prepare">5.1. The SameDocumentTransition interface</a>
-    <li><a href="#ref-for-dom-samedocumenttransition-prepare①">5.1.1. prepare()</a>
+    <li><a href="#ref-for-dom-domtransition-domupdated">5.2. The DOMTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-samedocumenttransition-abandon">
-   <b><a href="#dom-samedocumenttransition-abandon">#dom-samedocumenttransition-abandon</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="domtransition-tagged-elements">
+   <b><a href="#domtransition-tagged-elements">#domtransition-tagged-elements</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-samedocumenttransition-abandon">5.1. The SameDocumentTransition interface</a>
-    <li><a href="#ref-for-dom-samedocumenttransition-abandon①">5.1.2. abandon()</a>
+    <li><a href="#ref-for-domtransition-tagged-elements">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-tagged-elements①">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition-tagged-elements②">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-domtransition-tagged-elements③">6.9. Create transition pseudo-elements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-concluded">
+   <b><a href="#domtransition-concluded">#domtransition-concluded</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-concluded">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-domtransition-concluded①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-domtransition-concluded②">6.3. Perform an outgoing capture</a> <a href="#ref-for-domtransition-concluded③">(2)</a> <a href="#ref-for-domtransition-concluded④">(3)</a>
+    <li><a href="#ref-for-domtransition-concluded⑤">6.4. Skip the page transition</a> <a href="#ref-for-domtransition-concluded⑥">(2)</a>
+    <li><a href="#ref-for-domtransition-concluded⑦">6.6. Update transition DOM</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-dom-change-callback">
+   <b><a href="#domtransition-dom-change-callback">#domtransition-dom-change-callback</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-dom-change-callback">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-domtransition-dom-change-callback①">6.9. Create transition pseudo-elements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-dom-change-callback-called">
+   <b><a href="#domtransition-dom-change-callback-called">#domtransition-dom-change-callback-called</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-dom-change-callback-called">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition-dom-change-callback-called①">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-dom-change-callback-called②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-ready-promise">
+   <b><a href="#domtransition-ready-promise">#domtransition-ready-promise</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-ready-promise">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-ready-promise①">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-ready-promise②">6.4. Skip the page transition</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-dom-updated-promise">
+   <b><a href="#domtransition-dom-updated-promise">#domtransition-dom-updated-promise</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-dom-updated-promise">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-dom-updated-promise①">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-dom-updated-promise②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-dom-updated-promise③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domtransition-finished-promise">
+   <b><a href="#domtransition-finished-promise">#domtransition-finished-promise</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domtransition-finished-promise">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-finished-promise①">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition-finished-promise②">6.6. Update transition DOM</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-domtransition-skiptransition">
+   <b><a href="#dom-domtransition-skiptransition">#dom-domtransition-skiptransition</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-domtransition-skiptransition">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-dom-domtransition-skiptransition①">5.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="perform-pending-transition-operations">
@@ -2733,17 +2842,17 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
   <aside class="dfn-panel" data-for="perform-an-outgoing-capture">
    <b><a href="#perform-an-outgoing-capture">#perform-an-outgoing-capture</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-perform-an-outgoing-capture">5.1.1. prepare()</a>
+    <li><a href="#ref-for-perform-an-outgoing-capture">5.1.1. createTransition()</a>
     <li><a href="#ref-for-perform-an-outgoing-capture①">6.2. Perform pending transition operations</a>
     <li><a href="#ref-for-perform-an-outgoing-capture②">6.3. Perform an outgoing capture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abandon-the-page-transition">
-   <b><a href="#abandon-the-page-transition">#abandon-the-page-transition</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="skip-the-page-transition">
+   <b><a href="#skip-the-page-transition">#skip-the-page-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abandon-the-page-transition">5.1.1. prepare()</a>
-    <li><a href="#ref-for-abandon-the-page-transition①">5.1.2. abandon()</a>
-    <li><a href="#ref-for-abandon-the-page-transition②">6.3. Perform an outgoing capture</a> <a href="#ref-for-abandon-the-page-transition③">(2)</a> <a href="#ref-for-abandon-the-page-transition④">(3)</a> <a href="#ref-for-abandon-the-page-transition⑤">(4)</a> <a href="#ref-for-abandon-the-page-transition⑥">(5)</a>
+    <li><a href="#ref-for-skip-the-page-transition">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-skip-the-page-transition①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-skip-the-page-transition②">6.3. Perform an outgoing capture</a> <a href="#ref-for-skip-the-page-transition③">(2)</a> <a href="#ref-for-skip-the-page-transition④">(3)</a> <a href="#ref-for-skip-the-page-transition⑤">(4)</a> <a href="#ref-for-skip-the-page-transition⑥">(5)</a> <a href="#ref-for-skip-the-page-transition⑦">(6)</a> <a href="#ref-for-skip-the-page-transition⑧">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="capture-the-image">
@@ -2784,6 +2893,13 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
     <li><a href="#ref-for-create-transition-pseudo-elements">3. Pseudo-elements</a>
     <li><a href="#ref-for-create-transition-pseudo-elements①">6.3. Perform an outgoing capture</a>
     <li><a href="#ref-for-create-transition-pseudo-elements②">6.9. Create transition pseudo-elements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="call-the-dom-change-callback">
+   <b><a href="#call-the-dom-change-callback">#call-the-dom-change-callback</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-call-the-dom-change-callback">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-call-the-dom-change-callback①">6.4. Skip the page transition</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/css-shared-element-transitions/index.html
+++ b/css-shared-element-transitions/index.html
@@ -9,7 +9,7 @@
   <meta content="Bikeshed version 44af0bf3e, updated Fri Jul 29 17:05:16 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/css-shared-element-transitions/" rel="canonical">
   <link href="https://drafts.csswg.org/csslogo.ico" rel="icon">
-  <meta content="e8f3cb988b9d7b105191126097f87189cbaa5e56" name="document-revision">
+  <meta content="fb06ecc647825a6554296cb5d2e496562170b36a" name="document-revision">
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -746,7 +746,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">CSS Shared Element Transitions Module Level 1</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2022-08-19">19 August 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2022-08-26">26 August 2022</time></p>
    <details open>
     <summary>More details about this document</summary>
     <div data-fill-with="spec-metadata">
@@ -796,45 +796,47 @@ on screen, on paper, etc.
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
     <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#transitions-as-enhancements"><span class="secno">2</span> <span class="content">Transitions as an enhancement</span></a>
     <li>
-     <a href="#css-properties"><span class="secno">2</span> <span class="content">CSS properties</span></a>
+     <a href="#css-properties"><span class="secno">3</span> <span class="content">CSS properties</span></a>
      <ol class="toc">
-      <li><a href="#page-transition-tag-prop"><span class="secno">2.1</span> <span class="content"><span class="property">page-transition-tag</span></span></a>
+      <li><a href="#page-transition-tag-prop"><span class="secno">3.1</span> <span class="content"><span class="property">page-transition-tag</span></span></a>
      </ol>
-    <li><a href="#pseudo"><span class="secno">3</span> <span class="content">Pseudo-elements</span></a>
+    <li><a href="#pseudo"><span class="secno">4</span> <span class="content">Pseudo-elements</span></a>
     <li>
-     <a href="#concepts"><span class="secno">4</span> <span class="content">Concepts</span></a>
+     <a href="#concepts"><span class="secno">5</span> <span class="content">Concepts</span></a>
      <ol class="toc">
-      <li><a href="#page-transition-stacking-layer"><span class="secno">4.1</span> <span class="content">The <span>page-transition layer</span> stacking layer</span></a>
-      <li><a href="#captured-elements"><span class="secno">4.2</span> <span class="content"><span>Captured elements</span></span></a>
-      <li><a href="#additions-to-document"><span class="secno">4.3</span> <span class="content">Additions to <code class="idl"><span>Document</span></code></span></a>
+      <li><a href="#phases-concept"><span class="secno">5.1</span> <span class="content">Phases</span></a>
+      <li><a href="#page-transition-stacking-layer"><span class="secno">5.2</span> <span class="content">The <span>page-transition layer</span> stacking layer</span></a>
+      <li><a href="#captured-elements"><span class="secno">5.3</span> <span class="content"><span>Captured elements</span></span></a>
+      <li><a href="#additions-to-document"><span class="secno">5.4</span> <span class="content">Additions to <code class="idl"><span>Document</span></code></span></a>
      </ol>
     <li>
-     <a href="#api"><span class="secno">5</span> <span class="content">API</span></a>
+     <a href="#api"><span class="secno">6</span> <span class="content">API</span></a>
      <ol class="toc">
       <li>
-       <a href="#additions-to-document-api"><span class="secno">5.1</span> <span class="content">Additions to <code class="idl"><span>Document</span></code></span></a>
+       <a href="#additions-to-document-api"><span class="secno">6.1</span> <span class="content">Additions to <code class="idl"><span>Document</span></code></span></a>
        <ol class="toc">
-        <li><a href="#DOMTransition-prepare"><span class="secno">5.1.1</span> <span class="content"><code class="idl"><span>createTransition()</span></code></span></a>
+        <li><a href="#DOMTransition-prepare"><span class="secno">6.1.1</span> <span class="content"><code class="idl"><span>createTransition()</span></code></span></a>
        </ol>
       <li>
-       <a href="#the-domtransition-interface"><span class="secno">5.2</span> <span class="content">The <code class="idl"><span>DOMTransition</span></code> interface</span></a>
+       <a href="#the-domtransition-interface"><span class="secno">6.2</span> <span class="content">The <code class="idl"><span>DOMTransition</span></code> interface</span></a>
        <ol class="toc">
-        <li><a href="#DOMTransition-skipTransition"><span class="secno">5.2.1</span> <span class="content"><code class="idl"><span>skipTransition()</span></code></span></a>
+        <li><a href="#DOMTransition-skipTransition"><span class="secno">6.2.1</span> <span class="content"><code class="idl"><span>skipTransition()</span></code></span></a>
        </ol>
      </ol>
     <li>
-     <a href="#algorithms"><span class="secno">6</span> <span class="content">Algorithms</span></a>
+     <a href="#algorithms"><span class="secno">7</span> <span class="content">Algorithms</span></a>
      <ol class="toc">
-      <li><a href="#monkey-patch-to-rendering-algorithm"><span class="secno">6.1</span> <span class="content">Monkey patch to rendering</span></a>
-      <li><a href="#perform-pending-transition-operations-algorithm"><span class="secno">6.2</span> <span class="content"><span>Perform pending transition operations</span></span></a>
-      <li><a href="#perform-an-outgoing-capture-algorithm"><span class="secno">6.3</span> <span class="content"><span>Perform an outgoing capture</span></span></a>
-      <li><a href="#skip-the-page-transition-algorithm"><span class="secno">6.4</span> <span class="content">Skip the page transition</span></a>
-      <li><a href="#capture-the-image-algorithm"><span class="secno">6.5</span> <span class="content"><span>Capture the image</span></span></a>
-      <li><a href="#update-transition-dom-algorithm"><span class="secno">6.6</span> <span class="content"><span>Update transition DOM</span></span></a>
-      <li><a href="#compute-the-interest-rectangle-algorithm"><span class="secno">6.7</span> <span class="content"><span>Compute the interest rectangle</span></span></a>
-      <li><a href="#animate-a-page-transition-algorithm"><span class="secno">6.8</span> <span class="content"><span>Animate a page transition</span></span></a>
-      <li><a href="#create-transition-pseudo-elements-algorithm"><span class="secno">6.9</span> <span class="content"><span>Create transition pseudo-elements</span></span></a>
+      <li><a href="#monkey-patch-to-rendering-algorithm"><span class="secno">7.1</span> <span class="content">Monkey patches to rendering</span></a>
+      <li><a href="#perform-pending-transition-operations-algorithm"><span class="secno">7.2</span> <span class="content"><span>Perform pending transition operations</span></span></a>
+      <li><a href="#perform-an-outgoing-capture-algorithm"><span class="secno">7.3</span> <span class="content"><span>Perform an outgoing capture</span></span></a>
+      <li><a href="#skip-the-page-transition-algorithm"><span class="secno">7.4</span> <span class="content">Skip the page transition</span></a>
+      <li><a href="#capture-the-image-algorithm"><span class="secno">7.5</span> <span class="content"><span>Capture the image</span></span></a>
+      <li><a href="#update-transition-dom-algorithm"><span class="secno">7.6</span> <span class="content"><span>Update transition DOM</span></span></a>
+      <li><a href="#compute-the-interest-rectangle-algorithm"><span class="secno">7.7</span> <span class="content"><span>Compute the interest rectangle</span></span></a>
+      <li><a href="#animate-a-page-transition-algorithm"><span class="secno">7.8</span> <span class="content"><span>Animate a page transition</span></span></a>
+      <li><a href="#create-transition-pseudo-elements-algorithm"><span class="secno">7.9</span> <span class="content"><span>Create transition pseudo-elements</span></span></a>
      </ol>
     <li>
      <a href="#w3c-conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
@@ -866,10 +868,14 @@ on screen, on paper, etc.
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
-   <p>This spec describes the CSS and JS mechanics
-    of the single-page Page Transition API.</p>
-   <h2 class="heading settled" data-level="2" id="css-properties"><span class="secno">2. </span><span class="content">CSS properties</span><a class="self-link" href="#css-properties"></a></h2>
-   <h3 class="heading settled" data-level="2.1" id="page-transition-tag-prop"><span class="secno">2.1. </span><span class="content"><a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag">page-transition-tag</a></span><a class="self-link" href="#page-transition-tag-prop"></a></h3>
+   <p>This spec describes the CSS and JS mechanics of the single-page transition API.</p>
+   <h2 class="heading settled" data-level="2" id="transitions-as-enhancements"><span class="secno">2. </span><span class="content">Transitions as an enhancement</span><a class="self-link" href="#transitions-as-enhancements"></a></h2>
+   <p><em>This section is non-normative.</em></p>
+   <p>A key part of this API design is the view that an animated transition is an enhancement to a DOM change.</p>
+   <p>If a transition cannot run, or is skipped, the DOM change should still happen. If the DOM change should also be skipped, then that should be handled by another feature. The <a href="https://wicg.github.io/navigation-api/#navigate-event-class"><code>signal</code> on <code>NavigateEvent</code></a> is an example of a feature developers could use to handle this.</p>
+   <p>Although the transition API allows DOM changes to be asynchronous via the <code class="idl"><a data-link-type="idl" href="#dom-domtransitioninit-updatedom" id="ref-for-dom-domtransitioninit-updatedom">updateDOM</a></code> callback, the transition API is not responsible for queuing or otherwise scheduling the DOM changes, beyond the scheduling needed for the transition itself. Some asynchronous DOM changes can happen concurrently (e.g if they’re happening within independent components), whereas others need to queue, or abort an earlier change. This is best left to a feature or framework that has a more holistic view of the update.</p>
+   <h2 class="heading settled" data-level="3" id="css-properties"><span class="secno">3. </span><span class="content">CSS properties</span><a class="self-link" href="#css-properties"></a></h2>
+   <h3 class="heading settled" data-level="3.1" id="page-transition-tag-prop"><span class="secno">3.1. </span><span class="content"><a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag">page-transition-tag</a></span><a class="self-link" href="#page-transition-tag-prop"></a></h3>
    <table class="def propdef" data-link-for-hint="page-transition-tag">
     <tbody>
      <tr>
@@ -919,7 +925,7 @@ the following style in the <a data-link-type="dfn" href="https://drafts.csswg.or
   <c- k>page-transition-tag</c-><c- p>:</c-> root<c- p>;</c->
 <c- p>}</c->
 </code></pre>
-   <h2 class="heading settled" data-level="3" id="pseudo"><span class="secno">3. </span><span class="content">Pseudo-elements</span><a class="self-link" href="#pseudo"></a></h2>
+   <h2 class="heading settled" data-level="4" id="pseudo"><span class="secno">4. </span><span class="content">Pseudo-elements</span><a class="self-link" href="#pseudo"></a></h2>
    <p>While the UA is <a data-link-type="dfn" href="#animate-a-page-transition" id="ref-for-animate-a-page-transition">animating a page transition</a>,
 it creates the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="page-transition-pseudo-elements">page-transition pseudo-elements</dfn>,
 to represent the various items being animated.</p>
@@ -1043,8 +1049,11 @@ except it deals with the incoming element instead.</p>
    </dl>
    <p>The precise tree structure, and in particular the order of sibling
 pseudo-elements, is defined in the <a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements">Create transition pseudo-elements</a> algorithm.</p>
-   <h2 class="heading settled" data-level="4" id="concepts"><span class="secno">4. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
-   <h3 class="heading settled" data-level="4.1" id="page-transition-stacking-layer"><span class="secno">4.1. </span><span class="content">The <a data-link-type="dfn" href="#page-transition-layer" id="ref-for-page-transition-layer">page-transition layer</a> stacking layer</span><a class="self-link" href="#page-transition-stacking-layer"></a></h3>
+   <h2 class="heading settled" data-level="5" id="concepts"><span class="secno">5. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
+   <h3 class="heading settled" data-level="5.1" id="phases-concept"><span class="secno">5.1. </span><span class="content">Phases</span><a class="self-link" href="#phases-concept"></a></h3>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="phases">Phases</dfn> represent an ordered sequence of states. Since <a data-link-type="dfn" href="#phases" id="ref-for-phases">phases</a> are ordered, prose can refer to phases <dfn class="dfn-paneled" data-dfn-for="phases" data-dfn-type="dfn" data-noexport id="phases-before">before</dfn> a particular phase, meaning they appear earlier in the sequence, or <dfn class="dfn-paneled" data-dfn-for="phases" data-dfn-type="dfn" data-noexport id="phases-after">after</dfn> a particular phase, meaning they appear later in the sequence.</p>
+   <p>The initial phase is the first item in the sequence.</p>
+   <h3 class="heading settled" data-level="5.2" id="page-transition-stacking-layer"><span class="secno">5.2. </span><span class="content">The <a data-link-type="dfn" href="#page-transition-layer" id="ref-for-page-transition-layer">page-transition layer</a> stacking layer</span><a class="self-link" href="#page-transition-stacking-layer"></a></h3>
    <p>This specification introduces a stacking layer to the <a href="https://www.w3.org/TR/CSS2/zindex.html">Elaborate description of Stacking Contexts</a>.</p>
    <p>The <a class="css" data-link-type="maybe" href="#selectordef-page-transition" id="ref-for-selectordef-page-transition②">::page-transition</a> pseudo-element generates a new stacking context
 called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="page-transition-layer">page-transition layer</dfn> with the following characteristics:</p>
@@ -1064,7 +1073,7 @@ since that results in a circular dependency. Instead, this stacking context is a
 sibling of other page contents.</p>
    <p class="issue" id="issue-929cc26b"><a class="self-link" href="#issue-929cc26b"></a> Do we need to clarify that the stacking context for the root and top
 layer elements has filters and effects coming from the root element’s style?</p>
-   <h3 class="heading settled" data-level="4.2" id="captured-elements"><span class="secno">4.2. </span><span class="content"><a data-link-type="dfn" href="#captured-element" id="ref-for-captured-element">Captured elements</a></span><a class="self-link" href="#captured-elements"></a></h3>
+   <h3 class="heading settled" data-level="5.3" id="captured-elements"><span class="secno">5.3. </span><span class="content"><a data-link-type="dfn" href="#captured-element" id="ref-for-captured-element">Captured elements</a></span><a class="self-link" href="#captured-elements"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="captured-element">captured element</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> with the following:</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="captured element" data-dfn-type="dfn" data-noexport id="captured-element-outgoing-image">outgoing image</dfn>
@@ -1080,59 +1089,101 @@ layer elements has filters and effects coming from the root element’s style?</
      <p>an element or null. Initially null.</p>
      <p class="issue" id="issue-e6615d56"><a class="self-link" href="#issue-e6615d56"></a> The type of "element" needs to be linked or defined.</p>
    </dl>
-   <h3 class="heading settled" data-level="4.3" id="additions-to-document"><span class="secno">4.3. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code></span><a class="self-link" href="#additions-to-document"></a></h3>
+   <h3 class="heading settled" data-level="5.4" id="additions-to-document"><span class="secno">5.4. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code></span><a class="self-link" href="#additions-to-document"></a></h3>
    <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> additionally has:</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-active-dom-transition">active DOM transition</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition">DOMTransition</a></code> or null. Initially null.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-running-same-document-transition">running same document transition</dfn>
-    <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①">DOMTransition</a></code> or null. Initially null.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-transition-suppressing-rendering">transition suppressing rendering</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition②">DOMTransition</a></code> or null. Initially null.</p>
+     <p>a boolean. Initially false.</p>
    </dl>
-   <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
-   <h3 class="heading settled" data-level="5.1" id="additions-to-document-api"><span class="secno">5.1. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code></span><a class="self-link" href="#additions-to-document-api"></a></h3>
+   <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
+   <h3 class="heading settled" data-level="6.1" id="additions-to-document-api"><span class="secno">6.1. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code></span><a class="self-link" href="#additions-to-document-api"></a></h3>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- g>Document</c-></a> {
-    <a data-link-type="idl-name" href="#domtransition" id="ref-for-domtransition③"><c- n>DOMTransition</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition"><c- g>createTransition</c-></a>(<a data-link-type="idl-name" href="#dictdef-domtransitioninit" id="ref-for-dictdef-domtransitioninit"><c- n>DOMTransitionInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createTransition(init)" data-dfn-type="argument" data-export id="dom-document-createtransition-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-document-createtransition-init-init"></a></dfn>);
+    <a data-link-type="idl-name" href="#domtransition" id="ref-for-domtransition①"><c- n>DOMTransition</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition"><c- g>createTransition</c-></a>(<a data-link-type="idl-name" href="#dictdef-domtransitioninit" id="ref-for-dictdef-domtransitioninit"><c- n>DOMTransitionInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createTransition(init)" data-dfn-type="argument" data-export id="dom-document-createtransition-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-document-createtransition-init-init"></a></dfn>);
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></dfn> {
-    <a data-link-type="idl-name" href="#callbackdef-changedomcallback" id="ref-for-callbackdef-changedomcallback"><c- n>ChangeDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="ChangeDOMCallback " id="dom-domtransitioninit-changedom"><code><c- g>changeDOM</c-></code></dfn>;
+    <a data-link-type="idl-name" href="#callbackdef-updatedomcallback" id="ref-for-callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransitionInit" data-dfn-type="dict-member" data-export data-type="UpdateDOMCallback " id="dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></dfn>;
 };
 
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-changedomcallback"><code><c- g>ChangeDOMCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
+<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any"><c- b>any</c-></a>> ();
 </pre>
-   <h4 class="heading settled" data-level="5.1.1" id="DOMTransition-prepare"><span class="secno">5.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition①">createTransition()</a></code></span><a class="self-link" href="#DOMTransition-prepare"></a></h4>
+   <h4 class="heading settled" data-level="6.1.1" id="DOMTransition-prepare"><span class="secno">6.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-document-createtransition" id="ref-for-dom-document-createtransition①">createTransition()</a></code></span><a class="self-link" href="#DOMTransition-prepare"></a></h4>
    <div class="algorithm" data-algorithm="createTransition(init)" data-algorithm-for="Document">
      The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export id="dom-document-createtransition"><code>createTransition(<var>init</var>)</code></dfn> are as follows: 
     <ol>
      <li data-md>
-      <p>Let <var>transition</var> be a new <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition④">DOMTransition</a></code> object in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
+      <p>Let <var>transition</var> be a new <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition②">DOMTransition</a></code> object in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
      <li data-md>
-      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback" id="ref-for-domtransition-dom-change-callback">DOM change callback</a> to <var>init</var>[<code class="idl"><a data-link-type="idl" href="#dom-domtransitioninit-changedom" id="ref-for-dom-domtransitioninit-changedom">changeDOM</a></code>].</p>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-update-callback" id="ref-for-domtransition-dom-update-callback">DOM update callback</a> to <var>init</var>[<code class="idl"><a data-link-type="idl" href="#dom-domtransitioninit-updatedom" id="ref-for-dom-domtransitioninit-updatedom①">updateDOM</a></code>].</p>
      <li data-md>
       <p>Let <var>document</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated document</a>.</p>
      <li data-md>
-      <p>Let <var>transitionsToSkip</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of every <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑤">DOMTransition</a></code> within <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant Realm</a>,
-that has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded">concluded</a>,
-and is not <var>transition</var>.</p>
+      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition">active DOM transition</a> is not null, then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition">skip the page transition</a> <var>document</var>’s <span id="ref-for-document-active-dom-transition①">active DOM transition</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm①">relevant Realm</a>.</p>
+      <p class="note" role="note"><span>Note:</span> This can result in two asynchronous <a data-link-type="dfn" href="#domtransition-dom-update-callback" id="ref-for-domtransition-dom-update-callback①">DOM update callbacks</a> running concurrently. One for the <var>document</var>’s current <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition②">active DOM transition</a>, and another for this <var>transition</var>. As per the <a href="#transitions-as-enhancements">design of this feature</a>, it’s assumed that the developer is using another feature or framework to correctly schedule these DOM changes.</p>
      <li data-md>
-      <p class="assertion">Assert: The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> of <var>transitionsToSkip</var> is 0 or 1.</p>
-     <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>transitionToSkip</var> of <var>transitionsToSkip</var>, <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition">skip the page transition</a> <var>transitionToSkip</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
-     <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</a> is null.</p>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture①">pending same document transition outgoing capture</a> to <var>transition</var>.</p>
-      <p class="note" role="note"><span>Note:</span> This process continues in <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture">perform an outgoing capture</a>.</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition③">active DOM transition</a> to <var>transition</var>.</p>
+      <p class="note" role="note"><span>Note:</span> The process continues in <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture">perform an outgoing capture</a>.</p>
      <li data-md>
       <p>Return <var>transition</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="5.2" id="the-domtransition-interface"><span class="secno">5.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑥">DOMTransition</a></code> interface</span><a class="self-link" href="#the-domtransition-interface"></a></h3>
+   <div class="example" id="example-ed2c7772">
+    <a class="self-link" href="#example-ed2c7772"></a> If the default animations for the page transition are acceptable,
+    then kicking off a transition
+    requires nothing more than setting <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag②">page-transition-tag</a> in the page’s CSS,
+    and a single line of script to start it: 
+<pre class="highlight">document<c- p>.</c->createTransition<c- p>({</c->
+    updateDOM<c- p>()</c-> <c- p>{</c->
+        coolFramework<c- p>.</c->changeTheDOMToPageB<c- p>();</c->
+    <c- p>}</c->
+<c- p>});</c->
+</pre>
+    <p>If more precise management is needed, however,
+    transition elements can be managed in script:</p>
+<pre class="highlight"><c- k>async</c-> <c- a>function</c-> doTransition<c- p>()</c-> <c- p>{</c->
+    <c- c1>// Specify "outgoing" elements. The tag is used to match against</c->
+    <c- c1>// "incoming" elements they should transition to, and to refer to</c->
+    <c- c1>// the transitioning pseudo-element.</c->
+    document<c- p>.</c->querySelector<c- p>(</c-><c- t>'.old-message'</c-><c- p>).</c->style<c- p>.</c->pageTransitionTag <c- o>=</c-> <c- t>'message'</c-><c- p>;</c->
+
+    <c- a>const</c-> transition <c- o>=</c-> document<c- p>.</c->createTransition<c- p>({</c->
+        <c- k>async</c-> updateDOM<c- p>()</c-> <c- p>{</c->
+            <c- c1>// This callback is invoked by the browser when "outgoing"</c->
+            <c- c1>// capture finishes and the DOM can be switched to the new</c->
+            <c- c1>// state. No frames are rendered until this callback returns.</c->
+
+            <c- c1>// DOM changes may be asynchronous</c->
+            <c- k>await</c-> coolFramework<c- p>.</c->changeTheDOMToPageB<c- p>();</c->
+
+            <c- c1>// Tagging elements during the updateDOM() callback marks them as</c->
+            <c- c1>// "incoming", to be matched up with the same-tagged "outgoing"</c->
+            <c- c1>// elements marked previously and transitioned between.</c->
+            document<c- p>.</c->querySelector<c- p>(</c-><c- t>'.new-message'</c-><c- p>).</c->style<c- p>.</c->pageTransitionTag <c- o>=</c->
+                <c- t>'message'</c-><c- p>;</c->
+        <c- p>},</c->
+    <c- p>});</c->
+
+    <c- c1>// When ready resolves, all pseudo-elements for this transition have</c->
+    <c- c1>// been generated.</c->
+    <c- c1>// They can now be accessed in script to set up custom animations.</c->
+    <c- k>await</c-> transition<c- p>.</c->ready<c- p>;</c->
+
+    document<c- p>.</c->documentElement<c- p>.</c->animate<c- p>(</c->keyframes<c- p>,</c-> <c- p>{</c->
+        <c- p>...</c->animationOptions<c- p>,</c->
+        pseudoElement<c- o>:</c-> <c- t>'::page-transition-container(message)'</c-><c- p>,</c->
+    <c- p>});</c->
+
+    <c- c1>// When the finished promise resolves, that means the transition is</c->
+    <c- c1>// finished.</c->
+    <c- k>await</c-> transition<c- p>.</c->finished<c- p>;</c->
+<c- p>}</c->
+</pre>
+   </div>
+   <h3 class="heading settled" data-level="6.2" id="the-domtransition-interface"><span class="secno">6.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition③">DOMTransition</a></code> interface</span><a class="self-link" href="#the-domtransition-interface"></a></h3>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="domtransition"><code><c- g>DOMTransition</c-></code></dfn> {
     <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition"><c- g>skipTransition</c-></a>();
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-domtransition-finished"><code><c- g>finished</c-></code></dfn>;
@@ -1140,53 +1191,60 @@ and is not <var>transition</var>.</p>
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise③"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③"><c- b>undefined</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="attribute" data-export data-readonly data-type="Promise<undefined>" id="dom-domtransition-domupdated"><code><c- g>domUpdated</c-></code></dfn>;
 };
 </pre>
-   <div class="note" role="note"> The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑦">DOMTransition</a></code> represents and controls
+   <div class="note" role="note"> The <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition④">DOMTransition</a></code> represents and controls
     a single same-document transition. That is, it controls a transition where the
     starting and ending document are the same, possibly with changes to the
     document’s DOM structure. </div>
-   <p>A <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑧">DOMTransition</a></code> has the following:</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑤">DOMTransition</a></code> has the following:</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-tagged-elements">tagged elements</dfn>
     <dd data-md>
      <p>a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>,
 whose keys are <a data-link-type="dfn" href="#page-transition-tag" id="ref-for-page-transition-tag">page transition tags</a> and whose values are <a data-link-type="dfn" href="#captured-element" id="ref-for-captured-element①">captured elements</a>.
 Initially a new <span id="ref-for-ordered-map①">map</span>.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-concluded">concluded</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-phase">phase</dfn>
     <dd data-md>
-     <p>a boolean. Initially false.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-change-callback">DOM change callback</dfn>
+     <p>One of the following <a data-link-type="dfn" href="#phases" id="ref-for-phases①">phases</a>:</p>
+     <ol>
+      <li data-md>
+       <p>"<code>pending-capture</code>".</p>
+      <li data-md>
+       <p>"<code>dom-update-callback-called</code>".</p>
+      <li data-md>
+       <p>"<code>animating</code>".</p>
+      <li data-md>
+       <p>"<code>done</code>".</p>
+     </ol>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-update-callback">DOM update callback</dfn>
     <dd data-md>
-     <p>a <code class="idl"><a data-link-type="idl" href="#callbackdef-changedomcallback" id="ref-for-callbackdef-changedomcallback①">ChangeDOMCallback</a></code> or null. Initially null.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-change-callback-called">DOM change callback called</dfn>
-    <dd data-md>
-     <p>a boolean. Initially false.</p>
+     <p>an <code class="idl"><a data-link-type="idl" href="#callbackdef-updatedomcallback" id="ref-for-callbackdef-updatedomcallback①">UpdateDOMCallback</a></code> or null. Initially null.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-ready-promise">ready promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise④">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-dom-updated-promise">DOM updated promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm③">relevant Realm</a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="DOMTransition" data-dfn-type="dfn" data-noexport id="domtransition-finished-promise">finished promise</dfn>
     <dd data-md>
      <p>a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise⑥">Promise</a></code>.
-Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a>.</p>
+Initially <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> in <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm④">relevant Realm</a>.</p>
    </dl>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-finished" id="ref-for-dom-domtransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise">finished promise</a>.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-ready" id="ref-for-dom-domtransition-ready">ready</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps①">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this’s</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise">ready promise</a>.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-domupdated" id="ref-for-dom-domtransition-domupdated">domUpdated</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps②">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this’s</a> <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise">DOM updated promise</a>.</p>
-   <h4 class="heading settled" data-level="5.2.1" id="DOMTransition-skipTransition"><span class="secno">5.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition①">skipTransition()</a></code></span><a class="self-link" href="#DOMTransition-skipTransition"></a></h4>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-finished" id="ref-for-dom-domtransition-finished">finished</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this’s</a> <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise">finished promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-ready" id="ref-for-dom-domtransition-ready">ready</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps①">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this’s</a> <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise">ready promise</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-domtransition-domupdated" id="ref-for-dom-domtransition-domupdated">domUpdated</a></code> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#getter-steps" id="ref-for-getter-steps②">getter steps</a> are to return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this’s</a> <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise">DOM updated promise</a>.</p>
+   <h4 class="heading settled" data-level="6.2.1" id="DOMTransition-skipTransition"><span class="secno">6.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-domtransition-skiptransition" id="ref-for-dom-domtransition-skiptransition①">skipTransition()</a></code></span><a class="self-link" href="#DOMTransition-skipTransition"></a></h4>
    <div class="algorithm" data-algorithm="skipTransition()" data-algorithm-for="DOMTransition">
      The <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#method-steps" id="ref-for-method-steps①">method steps</a> for <dfn class="dfn-paneled idl-code" data-dfn-for="DOMTransition" data-dfn-type="method" data-export id="dom-domtransition-skiptransition"><code>skipTransition()</code></dfn> are: 
     <ol>
      <li data-md>
-      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a> has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded①">concluded</a>,
-then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①">skip the page transition</a> for <span id="ref-for-this①①">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a>'s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase">phase</a> is not "<code>done</code>",
+then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition①">skip the page transition</a> for <span id="ref-for-this①⓪">this</span> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
     </ol>
    </div>
-   <h2 class="heading settled" data-level="6" id="algorithms"><span class="secno">6. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-   <h3 class="heading settled" data-level="6.1" id="monkey-patch-to-rendering-algorithm"><span class="secno">6.1. </span><span class="content">Monkey patch to rendering</span><a class="self-link" href="#monkey-patch-to-rendering-algorithm"></a></h3>
+   <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+   <h3 class="heading settled" data-level="7.1" id="monkey-patch-to-rendering-algorithm"><span class="secno">7.1. </span><span class="content">Monkey patches to rendering</span><a class="self-link" href="#monkey-patch-to-rendering-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="monkey patch to rendering">
      Run the following steps before <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:mark-paint-timing">marking paint timing</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering">update the rendering</a> steps: 
     <ol>
@@ -1196,27 +1254,44 @@ then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-t
     <p class="note" role="note"><span>Note:</span> These steps will be added to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering①">update the rendering</a> in the HTML spec.
         As such, the prose style is written to match other steps in that algorithm.</p>
    </div>
-   <h3 class="heading settled" data-level="6.2" id="perform-pending-transition-operations-algorithm"><span class="secno">6.2. </span><span class="content"><a data-link-type="dfn" href="#perform-pending-transition-operations" id="ref-for-perform-pending-transition-operations①">Perform pending transition operations</a></span><a class="self-link" href="#perform-pending-transition-operations-algorithm"></a></h3>
+   <div class="algorithm" data-algorithm="suppress rendering">
+     Issue: Define where this sits within the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering②">update the rendering</a> steps. 
+    <ol>
+     <li data-md>
+      <p>For each <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> in <var>docs</var> with a <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering">transition suppressing rendering</a> of true:</p>
+      <p class="issue" id="issue-ac37ca1e"><a class="self-link" href="#issue-ac37ca1e"></a> Define this behavior. Lifecycle updates can still be triggered
+via script APIs which query style or layout information but no visual updates
+are presented to the user. Is this the same behavior as render-blocking?</p>
+      <p class="issue" id="issue-f6dfdcaa"><a class="self-link" href="#issue-f6dfdcaa"></a> How should input be handled when in this state? The last frame presented
+to the user will not reflect the DOM state as it asynchronously switches to
+the new version.</p>
+      <p class="note" role="note"><span>Note:</span> The aim is to prevent unintended DOM updates from being presented to the
+user after a cached snapshot for the elements has been captured. We wait for
+one rendering opportunity after prepare to present DOM mutations made by the
+author before prepare to be presented to the user. This is also the content
+captured in snapshots.</p>
+    </ol>
+    <p class="note" role="note"><span>Note:</span> These steps will be added to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering③">update the rendering</a> in the HTML spec.
+        As such, the prose style is written to match other steps in that algorithm.</p>
+   </div>
+   <h3 class="heading settled" data-level="7.2" id="perform-pending-transition-operations-algorithm"><span class="secno">7.2. </span><span class="content"><a data-link-type="dfn" href="#perform-pending-transition-operations" id="ref-for-perform-pending-transition-operations①">Perform pending transition operations</a></span><a class="self-link" href="#perform-pending-transition-operations-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="perform pending transition operations">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-pending-transition-operations">perform pending transition operations</dfn> given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <var>document</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-pending-transition-operations">perform pending transition operations</dfn> given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <var>document</var>,
         perform the following steps: 
     <ol>
      <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture②">pending same document transition outgoing capture</a> is not null, then:</p>
+      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition④">active DOM transition</a> is not null, then:</p>
       <ol>
        <li data-md>
-        <p><a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture①">Perform an outgoing capture</a> with <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture③">pending same document transition outgoing capture</a>.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition⑤">active DOM transition</a>'s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①">phase</a> is "<code>pending-capture</code>", then <a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture①">perform an outgoing capture</a> with <var>document</var>’s <span id="ref-for-document-active-dom-transition⑥">active DOM transition</span>.</p>
        <li data-md>
-        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture④">pending same document transition outgoing capture</a> to null.</p>
+        <p>Otherwise, if <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition⑦">active DOM transition</a>'s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase②">phase</a> is "<code>animating</code>", then <a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom">update transition DOM</a> for <var>document</var>’s <span id="ref-for-document-active-dom-transition⑧">active DOM transition</span>.</p>
       </ol>
-     <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition">running same document transition</a> is not null,
-then <a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom">update transition DOM</a> for <var>document</var>’s <span id="ref-for-document-running-same-document-transition①">running same document transition</span>.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="6.3" id="perform-an-outgoing-capture-algorithm"><span class="secno">6.3. </span><span class="content"><a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture②">Perform an outgoing capture</a></span><a class="self-link" href="#perform-an-outgoing-capture-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.3" id="perform-an-outgoing-capture-algorithm"><span class="secno">7.3. </span><span class="content"><a data-link-type="dfn" href="#perform-an-outgoing-capture" id="ref-for-perform-an-outgoing-capture②">Perform an outgoing capture</a></span><a class="self-link" href="#perform-an-outgoing-capture-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="perform an outgoing capture">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-an-outgoing-capture">perform an outgoing capture</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑨">DOMTransition</a></code> <var>transition</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="perform-an-outgoing-capture">perform an outgoing capture</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑥">DOMTransition</a></code> <var>transition</var>,
         perform the following steps: 
     <ol>
      <li data-md>
@@ -1226,13 +1301,13 @@ then <a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-tr
      <li data-md>
       <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window①">associated document</a>.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>element</var> of every <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element">pseudo-element</a> connected to <var>document</var>,
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>element</var> of every <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element">pseudo-element</a> connected to <var>document</var>,
 in <a href="https://drafts.csswg.org/css2/#painting-order">paint order</a>:</p>
       <p class="issue" id="issue-ad1ca140"><a class="self-link" href="#issue-ad1ca140"></a> The link for "paint order" doesn’t seem right.
     Is there a more canonical definition?</p>
       <ol>
        <li data-md>
-        <p>Let <var>transitionTag</var> be the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value">computed value</a> of <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag②">page-transition-tag</a> for <var>element</var>.</p>
+        <p>Let <var>transitionTag</var> be the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value">computed value</a> of <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag③">page-transition-tag</a> for <var>element</var>.</p>
        <li data-md>
         <p>If <var>transitionTag</var> is <a class="css" data-link-type="maybe" href="#valdef-page-transition-tag-none" id="ref-for-valdef-page-transition-tag-none">none</a>,
 or <var>element</var> is <a data-link-type="dfn" href="https://drafts.csswg.org/css-images-4/#element-not-rendered" id="ref-for-element-not-rendered">not rendered</a>,
@@ -1247,7 +1322,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
          <li data-md>
           <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root①">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation">fragmentation</a>.</p>
         </ul>
-        <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition②">skip the page transition</a> for <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code> in <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑥">relevant Realm</a>,
+        <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition②">skip the page transition</a> for <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code> in <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm⑤">relevant Realm</a>,
     and return.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
@@ -1286,57 +1361,49 @@ will cause the view box to coincide with <var>element</var>’s <a data-link-typ
         <p>Set <var>taggedElements</var>[<var>transitionTag</var>] to <var>capture</var>.</p>
       </ol>
      <li data-md>
-      <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering">transition suppressing rendering</a> to <var>transition</var>.</p>
-     <li data-md>
-      <p>Suppress rendering opportunities for <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window②">associated document</a>.</p>
-      <p class="note" role="note"><span>Note:</span> The aim is to prevent unintended DOM updates from being presented to the
-user after a cached snapshot for the elements has been captured. We wait for
-one rendering opportunity after prepare to present DOM mutations made by the
-author before prepare to be presented to the user. This is also the content
-captured in snapshots.</p>
-      <p class="issue" id="issue-edbf8829"><a class="self-link" href="#issue-edbf8829"></a> Further clarify this behavior. Lifecycle updates can still be triggered
-via script APIs which query style or layout information but no visual updates
-are presented to the user. Is this the same behavior as render-blocking?</p>
-      <p class="issue" id="issue-f6dfdcaa"><a class="self-link" href="#issue-f6dfdcaa"></a> How should input be handled when in this state? The last frame presented
-to the user will not reflect the DOM state as it asynchronously switches to
-the new version.</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering①">transition suppressing rendering</a> to true.</p>
      <li data-md>
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task" id="ref-for-queue-a-global-task">Queue a global task</a> on the <a data-link-type="dfn">DOM manipulation task source</a>,
-given <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global③">relevant global object</a>,
+given <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global object</a>,
 to execute the following steps:</p>
       <p class="note" role="note"><span>Note:</span> A task is queued here because the texture read back in <a data-link-type="dfn" href="#capture-the-image" id="ref-for-capture-the-image①">capturing the image</a> may be async,
         although the render steps in the HTML spec act as if it’s synchronous.</p>
       <ol>
        <li data-md>
-        <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded②">concluded</a>, then abort these steps.</p>
+        <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase③">phase</a> is "<code>done</code>", then abort these steps.</p>
         <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition③">skipped</a> before this point.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="#call-the-dom-change-callback" id="ref-for-call-the-dom-change-callback">Call the DOM change callback</a> of <var>transition</var>.</p>
+        <p><a data-link-type="dfn" href="#call-the-dom-update-callback" id="ref-for-call-the-dom-update-callback">Call the DOM update callback</a> of <var>transition</var>.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled" id="ref-for-dfn-perform-steps-once-promise-is-settled">React</a> to <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-updated-promise" id="ref-for-domtransition-dom-updated-promise①">DOM updated promise</a>:</p>
         <ul>
          <li data-md>
-          <p>If the promise does not settle within an implementation-defined timeout, then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition④">skip the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
+          <p>If the promise does not settle within an implementation-defined timeout, then:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase④">phase</a> is "<code>done</code>", then return.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition④">skipped</a> before this point.</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑤">Skip the page transition</a> <var>transition</var> with a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#timeouterror" id="ref-for-timeouterror">TimeoutError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
+          </ol>
          <li data-md>
           <p>If the promise was fulfilled, then:</p>
           <ol>
            <li data-md>
-            <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded③">concluded</a>, then return.</p>
-            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑤">skipped</a> before this point.</p>
+            <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑤">phase</a> is "<code>done</code>", then return.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑥">skipped</a> before this point.</p>
            <li data-md>
-            <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering①">transition suppressing rendering</a> to null.</p>
-           <li data-md>
-            <p>Stop suppressing rendering opportunities for <var>transition</var>’s Document.</p>
+            <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering②">transition suppressing rendering</a> to false.</p>
            <li data-md>
             <p>Set <var>usedTransitionTags</var> to a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>.</p>
            <li data-md>
-            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>element</var> of every <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element①">pseudo-element</a> connected to <var>document</var>,
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>element</var> of every <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element①">pseudo-element</a> connected to <var>document</var>,
 in <a href="https://drafts.csswg.org/css2/#painting-order">paint order</a>:</p>
             <p class="issue" id="issue-ad1ca140①"><a class="self-link" href="#issue-ad1ca140①"></a> The link for "paint order" doesn’t seem right.
     Is there a more canonical definition?</p>
             <ol>
              <li data-md>
-              <p>Let <var>transitionTag</var> be the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag③">page-transition-tag</a> for <var>element</var>.</p>
+              <p>Let <var>transitionTag</var> be the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag④">page-transition-tag</a> for <var>element</var>.</p>
              <li data-md>
               <p>If <var>transitionTag</var> is <a class="css" data-link-type="maybe" href="#valdef-page-transition-tag-none" id="ref-for-valdef-page-transition-tag-none①">none</a>,
 or <var>element</var> is <a data-link-type="dfn" href="https://drafts.csswg.org/css-images-4/#element-not-rendered" id="ref-for-element-not-rendered①">not rendered</a>,
@@ -1351,7 +1418,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-cont
                <li data-md>
                 <p><var>element</var> is not <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-root" id="ref-for-concept-tree-root③">root</a> and <var>element</var> allows <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation" id="ref-for-fragmentation①">fragmentation</a>.</p>
               </ul>
-              <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑥">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>,
+              <p>Then <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑦">skip the page transition</a> <var>transition</var> with an "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>,
     and return.</p>
              <li data-md>
               <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>transitionTag</var> to <var>usedTransitionTags</var>.</p>
@@ -1377,106 +1444,48 @@ then set <var>taggedElements</var>[<var>transitionTag</var>] to a new <a data-li
           <p>If the promise was rejected with reason <var>r</var>, then:</p>
           <ol>
            <li data-md>
-            <p>If <var>transition</var> has <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded④">concluded</a>, then return.</p>
-            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑦">skipped</a> before this point.</p>
+            <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑥">phase</a> is "<code>done</code>", then return.</p>
+            <p class="note" role="note"><span>Note:</span> This happens if <var>transition</var> was <a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑧">skipped</a> before this point.</p>
            <li data-md>
-            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑧">Skip the page transition</a> <var>transition</var> with <var>r</var>.</p>
+            <p><a data-link-type="dfn" href="#skip-the-page-transition" id="ref-for-skip-the-page-transition⑨">Skip the page transition</a> <var>transition</var> with <var>r</var>.</p>
           </ol>
         </ul>
       </ol>
     </ol>
    </div>
-   <div class="example" id="example-6af13d7b">
-    <a class="self-link" href="#example-6af13d7b"></a> If the default animations for the page transition are acceptable,
-    then kicking off a transition
-    requires nothing more than setting <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag④">page-transition-tag</a> in the page’s CSS,
-    and a single line of script to start it: 
-<pre class="highlight"><c- ow>new</c-> DOMTransition<c- p>()</c->
-  <c- p>.</c->start<c- p>(()=></c->coolFramework<c- p>.</c->changeTheDOMToPageB<c- p>());</c->
-</pre>
-    <p>If more precise management is needed, however,
-    transition elements can be managed in script:</p>
-<pre class="highlight"><c- k>async</c-> <c- a>function</c-> doTransition<c- p>()</c-> <c- p>{</c->
-  <c- a>let</c-> transition <c- o>=</c-> <c- ow>new</c-> DOMTransition<c- p>();</c->
-
-  <c- c1>// Specify "outgoing" elements. The tag is used to match against</c->
-  <c- c1>// "incoming" elements they should transition to, and to refer to</c->
-  <c- c1>// the transitioning pseudo-element.</c->
-  document<c- p>.</c->querySelector<c- p>(</c-><c- u>".old-message"</c-><c- p>).</c->style<c- p>.</c->pageTransitionTag <c- o>=</c-> <c- u>"message"</c-><c- p>;</c->
-
-  <c- c1>// The prepare() call freezes the page’s rendering, and triggers</c->
-  <c- c1>// an async operation to capture snapshots for the offered elements.</c->
-  <c- k>await</c-> transition<c- p>.</c->prepare<c- p>(</c-><c- k>async</c-> <c- p>()</c-> <c- p>=></c-> <c- p>{</c->
-    <c- c1>// This callback is invoked by the browser when "outgoing"</c->
-    <c- c1>// capture  finishes and the DOM can be switched to the new</c->
-    <c- c1>// state. No frames are rendered until this callback returns.</c->
-
-    <c- c1>// Asynchronously load the new page.</c->
-    <c- k>await</c-> coolFramework<c- p>.</c->changeTheDOMToPageB<c- p>();</c->
-
-    <c- c1>// Tagging elements during the .start() callback marks them as</c->
-    <c- c1>// "incoming", to be matched up with the same-tagged "outgoing"</c->
-    <c- c1>// elements marked previously and transitioned between.</c->
-    document<c- p>.</c->querySelector<c- p>(</c-><c- u>".new-message"</c-><c- p>).</c->style<c- p>.</c->pageTransitionTag <c- o>=</c-> <c- u>"message"</c-><c- p>;</c->
-  <c- p>});</c->
-
-  <c- c1>// When the promise returned by prepare() resolves, all pseudo-elements</c->
-  <c- c1>// for this transition have been generated. They can now be accessed</c->
-  <c- c1>// in script to set up custom animations.</c->
-  document<c- p>.</c->documentElement<c- p>.</c->animate<c- p>(</c->
-    keyframes<c- p>,</c->
-    <c- p>{...</c->animationOptions<c- p>,</c->
-     pseudoElement<c- o>:</c-> <c- u>"::page-transition-container(message)"</c-><c- p>,</c->
-    <c- p>}</c->
-  <c- p>);</c->
-
-  <c- c1>// When the finished promise resolves, that means the transition is</c->
-  <c- c1>// finished (either completed successfully or abandoned).</c->
-  <c- k>await</c-> transition<c- p>.</c->finished<c- p>;</c->
-<c- p>}</c->
-</pre>
-   </div>
-   <h3 class="heading settled" data-level="6.4" id="skip-the-page-transition-algorithm"><span class="secno">6.4. </span><span class="content">Skip the page transition</span><a class="self-link" href="#skip-the-page-transition-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.4" id="skip-the-page-transition-algorithm"><span class="secno">7.4. </span><span class="content">Skip the page transition</span><a class="self-link" href="#skip-the-page-transition-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="skip the page transition">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="skip-the-page-transition">skip the page transition</dfn> for <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①⓪">DOMTransition</a></code> <var>transition</var> with reason <var>reason</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="skip-the-page-transition">skip the page transition</dfn> for <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑦">DOMTransition</a></code> <var>transition</var> with reason <var>reason</var>: 
     <ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>transition</var> has not <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑤">concluded</a>.</p>
+      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global③">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window②">associated document</a>.</p>
      <li data-md>
-      <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called">DOM change callback called</a> is false, then <a data-link-type="dfn" href="#call-the-dom-change-callback" id="ref-for-call-the-dom-change-callback①">call the DOM change callback</a> of <var>transition</var>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition⑨">active DOM transition</a> is <var>transition</var>.</p>
      <li data-md>
-      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global④">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window③">associated document</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑦">phase</a> is not "<code>done</code>".</p>
      <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-pending-same-document-transition-outgoing-capture" id="ref-for-document-pending-same-document-transition-outgoing-capture⑤">pending same document transition outgoing capture</a> is <var>transition</var>,
-then set <var>document</var>’s <span id="ref-for-document-pending-same-document-transition-outgoing-capture⑥">pending same document transition outgoing capture</span> to null.</p>
+      <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑧">phase</a> is <a data-link-type="dfn" href="#phases-before" id="ref-for-phases-before">before</a> "<code>dom-update-callback-called</code>", then <a data-link-type="dfn" href="#call-the-dom-update-callback" id="ref-for-call-the-dom-update-callback①">call the DOM update callback</a> of <var>transition</var>.</p>
      <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering②">transition suppressing rendering</a> is <var>transition</var>, then:</p>
-      <ol>
-       <li data-md>
-        <p>Stop suppressing rendering opportunities, if suppressed, for <var>document</var>.</p>
-        <p class="issue" id="issue-2b1a73c3"><a class="self-link" href="#issue-2b1a73c3"></a> "suppressing rendering opportunities" needs to be linked/defined.</p>
-       <li data-md>
-        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering③">transition suppressing rendering</a> to null.</p>
-      </ol>
+      <p>Set <a data-link-type="dfn" href="#document-transition-suppressing-rendering" id="ref-for-document-transition-suppressing-rendering③">transition suppressing rendering</a> to false.</p>
      <li data-md>
-      <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition②">running same document transition</a> is <var>transition</var>, then:</p>
+      <p>If <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase⑨">phase</a> is equal to or <a data-link-type="dfn" href="#phases-after" id="ref-for-phases-after">after</a> "<code>animating</code>", then:</p>
       <ol>
        <li data-md>
         <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements④">page-transition pseudo-elements</a> from <var>document</var>.</p>
         <p class="issue" id="issue-80506344"><a class="self-link" href="#issue-80506344"></a> There needs to be a definition/link for "remove".</p>
         <p class="issue" id="issue-cc250ace"><a class="self-link" href="#issue-cc250ace"></a> There needs to be a definition/link for "associated".</p>
-       <li data-md>
-        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition③">running same document transition</a> to null.</p>
       </ol>
      <li data-md>
-      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑥">concluded</a> to true.</p>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①⓪">phase</a> to "<code>done</code>".</p>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition①⓪">active DOM transition</a> to null.</p>
      <li data-md>
       <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-ready-promise" id="ref-for-domtransition-ready-promise②">ready promise</a> with <var>reason</var>.</p>
      <li data-md>
       <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#reject" id="ref-for-reject①">Reject</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise①">finished promise</a> with <var>reason</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="6.5" id="capture-the-image-algorithm"><span class="secno">6.5. </span><span class="content"><a data-link-type="dfn" href="#capture-the-image" id="ref-for-capture-the-image②">Capture the image</a></span><a class="self-link" href="#capture-the-image-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.5" id="capture-the-image-algorithm"><span class="secno">7.5. </span><span class="content"><a data-link-type="dfn" href="#capture-the-image" id="ref-for-capture-the-image②">Capture the image</a></span><a class="self-link" href="#capture-the-image-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="capture the image">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="capture the image|capturing the image" data-noexport id="capture-the-image">capture the image</dfn> given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> <var>element</var>, perform the following steps.
     They return an image. 
@@ -1493,7 +1502,7 @@ over an infinite transparent canvas with the following characteristics:</p>
 then the transform is ignored.</p>
         <p class="note" role="note"><span>Note:</span> This transform is applied to the snapshot using the <code>transform</code> property of the associated <span class="css">::page-transition-container</span> pseudo-element.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate③">For each</a> <var>descendant</var> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including descendant</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element②">pseudo-element</a> of <var>element</var>,
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>descendant</var> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including descendant</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#pseudo-element" id="ref-for-pseudo-element②">pseudo-element</a> of <var>element</var>,
 if <var>descendant</var> has a <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of <a class="property css" data-link-type="property" href="#propdef-page-transition-tag" id="ref-for-propdef-page-transition-tag⑤">page-transition-tag</a> that is not <a class="css" data-link-type="maybe" href="#valdef-page-transition-tag-none" id="ref-for-valdef-page-transition-tag-none②">none</a>,
 then skip painting <var>descendant</var>.</p>
         <p class="note" role="note"><span>Note:</span> This is necessary since the descendant will generate its own snapshot which will be displayed and animated independently.</p>
@@ -1509,12 +1518,12 @@ then skip painting <var>descendant</var>.</p>
 The natural size of the image is equal to the <var>interestRectangle</var> bounds.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="6.6" id="update-transition-dom-algorithm"><span class="secno">6.6. </span><span class="content"><a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom②">Update transition DOM</a></span><a class="self-link" href="#update-transition-dom-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.6" id="update-transition-dom-algorithm"><span class="secno">7.6. </span><span class="content"><a data-link-type="dfn" href="#update-transition-dom" id="ref-for-update-transition-dom②">Update transition DOM</a></span><a class="self-link" href="#update-transition-dom-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="update transition DOM">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="update-transition-dom">update transition DOM</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①①">DOMTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="update-transition-dom">update transition DOM</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑧">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
-      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑤">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window④">associated document</a>.</p>
+      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global④">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window③">associated document</a>.</p>
      <li data-md>
       <p>For each <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑤">page-transition pseudo-elements</a> associated with <var>transition</var>,
 check whether there is an active animation associated with this pseudo-element.</p>
@@ -1524,13 +1533,13 @@ check whether there is an active animation associated with this pseudo-element.<
       <p class="issue" id="issue-7108de0e"><a class="self-link" href="#issue-7108de0e"></a> There needs to be a definition/link for "active animation".</p>
       <ol>
        <li data-md>
-        <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-concluded" id="ref-for-domtransition-concluded⑦">concluded</a> to true.</p>
+        <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①①">phase</a> to "<code>done</code>".</p>
        <li data-md>
         <p>Remove all associated <a data-link-type="dfn" href="#page-transition-pseudo-elements" id="ref-for-page-transition-pseudo-elements⑦">page-transition pseudo-elements</a> from <var>document</var>.</p>
         <p class="issue" id="issue-80506344①"><a class="self-link" href="#issue-80506344①"></a> There needs to be a definition/link for "remove".</p>
         <p class="issue" id="issue-cc250ace①"><a class="self-link" href="#issue-cc250ace①"></a> There needs to be a definition/link for "associated".</p>
        <li data-md>
-        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition④">running same document transition</a> to null.</p>
+        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-active-dom-transition" id="ref-for-document-active-dom-transition①①">active DOM transition</a> to null.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve①">Resolve</a> <var>transition</var>’s<a data-link-type="dfn" href="#domtransition-finished-promise" id="ref-for-domtransition-finished-promise②">finished promise</a>.</p>
        <li data-md>
@@ -1553,7 +1562,7 @@ get c0 continuity.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="6.7" id="compute-the-interest-rectangle-algorithm"><span class="secno">6.7. </span><span class="content"><a data-link-type="dfn" href="#computing-the-interest-rectangle" id="ref-for-computing-the-interest-rectangle①">Compute the interest rectangle</a></span><a class="self-link" href="#compute-the-interest-rectangle-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.7" id="compute-the-interest-rectangle-algorithm"><span class="secno">7.7. </span><span class="content"><a data-link-type="dfn" href="#computing-the-interest-rectangle" id="ref-for-computing-the-interest-rectangle①">Compute the interest rectangle</a></span><a class="self-link" href="#compute-the-interest-rectangle-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="computing the interest rectangle">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="computing the interest rectangle|compute the interest rectangle" data-noexport id="computing-the-interest-rectangle">compute the interest rectangle</dfn> of an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> <var>el</var>, perform the following steps.
     They return a rectangle. 
@@ -1571,9 +1580,9 @@ then return a rectangle that is equal to <var>el</var>’s <a data-link-type="df
       <p class="issue" id="issue-c9dce14f"><a class="self-link" href="#issue-c9dce14f"></a> Define the algorithm used to clip the snapshot when it exceeds max size.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-level="6.8" id="animate-a-page-transition-algorithm"><span class="secno">6.8. </span><span class="content"><a data-link-type="dfn" href="#animate-a-page-transition" id="ref-for-animate-a-page-transition③">Animate a page transition</a></span><a class="self-link" href="#animate-a-page-transition-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.8" id="animate-a-page-transition-algorithm"><span class="secno">7.8. </span><span class="content"><a data-link-type="dfn" href="#animate-a-page-transition" id="ref-for-animate-a-page-transition③">Animate a page transition</a></span><a class="self-link" href="#animate-a-page-transition-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="animate a page transition">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="animate-a-page-transition">animate a page transition</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①②">DOMTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="animate-a-page-transition">animate a page transition</dfn> given a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition⑨">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
       <p>Generate a <a class="production css" data-link-type="type">&lt;keyframe></a> named "page-transition-fade-out" in <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua" id="ref-for-cascade-origin-ua①⓪">user-agent origin</a> as follows:</p>
@@ -1628,11 +1637,7 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
 </code></pre>
       </ol>
      <li data-md>
-      <p>Let <var>document</var> be <var>transition</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑥">relevant global object’s</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window⑤">associated document</a>.</p>
-     <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition⑤">running same document transition</a> is null.</p>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-running-same-document-transition" id="ref-for-document-running-same-document-transition⑥">running same document transition</a> to <var>transition</var>.</p>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①②">phase</a> to "<code>animating</code>".</p>
     </ol>
     <p class="issue" id="issue-4306640b"><a class="self-link" href="#issue-4306640b"></a> How are keyframes scoped to user-agent origin? We could decide
         scope based on whether <code>animation-name</code> in the computed style
@@ -1641,9 +1646,9 @@ html:<c- nf>:page-transition-incoming-image</c-><c- p>(</c->*<c- p>)</c-> <c- p>
         incoming elements change.</p>
     <p class="issue" id="issue-741cd9b6"><a class="self-link" href="#issue-741cd9b6"></a> We need to better define how the real new DOM is not painted during the animation.</p>
    </div>
-   <h3 class="heading settled" data-level="6.9" id="create-transition-pseudo-elements-algorithm"><span class="secno">6.9. </span><span class="content"><a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements②">Create transition pseudo-elements</a></span><a class="self-link" href="#create-transition-pseudo-elements-algorithm"></a></h3>
+   <h3 class="heading settled" data-level="7.9" id="create-transition-pseudo-elements-algorithm"><span class="secno">7.9. </span><span class="content"><a data-link-type="dfn" href="#create-transition-pseudo-elements" id="ref-for-create-transition-pseudo-elements②">Create transition pseudo-elements</a></span><a class="self-link" href="#create-transition-pseudo-elements-algorithm"></a></h3>
    <div class="algorithm" data-algorithm="create transition pseudo-elements">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-transition-pseudo-elements">create transition pseudo-elements</dfn> for a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①③">DOMTransition</a></code> <var>transition</var>: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="create-transition-pseudo-elements">create transition pseudo-elements</dfn> for a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①⓪">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
       <p>Let <var>transitionRoot</var> be the result of creating a new <a class="css" data-link-type="maybe" href="#selectordef-page-transition" id="ref-for-selectordef-page-transition③">::page-transition</a> pseudo-element.</p>
@@ -1724,15 +1729,15 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
       </ol>
     </ol>
    </div>
-   <div class="algorithm" data-algorithm="call the DOM change callback">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="call-the-dom-change-callback">call the DOM change callback</dfn> of a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①④">DOMTransition</a></code> <var>transition</var>: 
+   <div class="algorithm" data-algorithm="call the DOM update callback">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="call-the-dom-update-callback">call the DOM update callback</dfn> of a <code class="idl"><a data-link-type="idl" href="#domtransition" id="ref-for-domtransition①①">DOMTransition</a></code> <var>transition</var>: 
     <ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called①">DOM change callback called</a> is false.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①③">phase</a> is <a data-link-type="dfn" href="#phases-before" id="ref-for-phases-before①">before</a> "<code>dom-update-callback-called</code>".</p>
      <li data-md>
-      <p>Let <var>callbackPromise</var> be the result of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#invoke-a-callback-function" id="ref-for-invoke-a-callback-function">invoking</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback" id="ref-for-domtransition-dom-change-callback①">DOM change callback</a>.</p>
+      <p>Let <var>callbackPromise</var> be the result of <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#invoke-a-callback-function" id="ref-for-invoke-a-callback-function">invoking</a> <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-update-callback" id="ref-for-domtransition-dom-update-callback②">DOM update callback</a>.</p>
      <li data-md>
-      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-dom-change-callback-called" id="ref-for-domtransition-dom-change-callback-called②">DOM change callback called</a> to true.</p>
+      <p>Set <var>transition</var>’s <a data-link-type="dfn" href="#domtransition-phase" id="ref-for-domtransition-phase①④">phase</a> to "<code>dom-update-callback-called</code>".</p>
      <li data-md>
       <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled" id="ref-for-dfn-perform-steps-once-promise-is-settled①">React</a> to <var>callbackPromise</var>:</p>
       <ul>
@@ -1838,470 +1843,455 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#animate-a-page-transition">animate a page transition</a><span>, in § 6.8</span>
-   <li><a href="#call-the-dom-change-callback">call the DOM change callback</a><span>, in § 6.9</span>
-   <li><a href="#captured-element">captured element</a><span>, in § 4.2</span>
-   <li><a href="#capture-the-image">capture the image</a><span>, in § 6.5</span>
-   <li><a href="#capture-the-image">capturing the image</a><span>, in § 6.5</span>
-   <li><a href="#dom-domtransitioninit-changedom">changeDOM</a><span>, in § 5.1</span>
-   <li><a href="#callbackdef-changedomcallback">ChangeDOMCallback</a><span>, in § 5.1</span>
-   <li><a href="#computing-the-interest-rectangle">compute the interest rectangle</a><span>, in § 6.7</span>
-   <li><a href="#computing-the-interest-rectangle">computing the interest rectangle</a><span>, in § 6.7</span>
-   <li><a href="#domtransition-concluded">concluded</a><span>, in § 5.2</span>
-   <li><a href="#dom-document-createtransition">createTransition(init)</a><span>, in § 5.1.1</span>
-   <li><a href="#create-transition-pseudo-elements">create transition pseudo-elements</a><span>, in § 6.9</span>
-   <li><a href="#valdef-page-transition-tag-custom-ident">&lt;custom-ident></a><span>, in § 2.1</span>
-   <li><a href="#domtransition-dom-change-callback">DOM change callback</a><span>, in § 5.2</span>
-   <li><a href="#domtransition-dom-change-callback-called">DOM change callback called</a><span>, in § 5.2</span>
-   <li><a href="#domtransition">DOMTransition</a><span>, in § 5.2</span>
-   <li><a href="#dictdef-domtransitioninit">DOMTransitionInit</a><span>, in § 5.1</span>
-   <li><a href="#dom-domtransition-domupdated">domUpdated</a><span>, in § 5.2</span>
-   <li><a href="#domtransition-dom-updated-promise">DOM updated promise</a><span>, in § 5.2</span>
-   <li><a href="#dom-domtransition-finished">finished</a><span>, in § 5.2</span>
-   <li><a href="#domtransition-finished-promise">finished promise</a><span>, in § 5.2</span>
-   <li><a href="#captured-element-incoming-element">incoming element</a><span>, in § 4.2</span>
-   <li><a href="#valdef-page-transition-tag-none">none</a><span>, in § 2.1</span>
-   <li><a href="#captured-element-outgoing-image">outgoing image</a><span>, in § 4.2</span>
-   <li><a href="#captured-element-outgoing-styles">outgoing styles</a><span>, in § 4.2</span>
-   <li><a href="#selectordef-page-transition">::page-transition</a><span>, in § 3</span>
-   <li><a href="#selectordef-page-transition-container-pt-tag-selector">::page-transition-container( &lt;pt-tag-selector> )</a><span>, in § 3</span>
-   <li><a href="#selectordef-page-transition-image-wrapper-pt-tag-selector">::page-transition-image-wrapper( &lt;pt-tag-selector> )</a><span>, in § 3</span>
-   <li><a href="#selectordef-page-transition-incoming-image-pt-tag-selector">::page-transition-incoming-image( &lt;pt-tag-selector> )</a><span>, in § 3</span>
-   <li><a href="#page-transition-layer">page-transition layer</a><span>, in § 4.1</span>
-   <li><a href="#selectordef-page-transition-outgoing-image-pt-tag-selector">::page-transition-outgoing-image( &lt;pt-tag-selector> )</a><span>, in § 3</span>
-   <li><a href="#page-transition-pseudo-elements">page-transition pseudo-elements</a><span>, in § 3</span>
-   <li><a href="#page-transition-tag">page transition tag</a><span>, in § 2.1</span>
-   <li><a href="#propdef-page-transition-tag">page-transition-tag</a><span>, in § 2.1</span>
-   <li><a href="#document-pending-same-document-transition-outgoing-capture">pending same document transition outgoing capture</a><span>, in § 4.3</span>
-   <li><a href="#perform-an-outgoing-capture">perform an outgoing capture</a><span>, in § 6.3</span>
-   <li><a href="#perform-pending-transition-operations">perform pending transition operations</a><span>, in § 6.2</span>
-   <li><a href="#typedef-pt-tag-selector">&lt;pt-tag-selector></a><span>, in § 3</span>
-   <li><a href="#dom-domtransition-ready">ready</a><span>, in § 5.2</span>
-   <li><a href="#domtransition-ready-promise">ready promise</a><span>, in § 5.2</span>
-   <li><a href="#document-running-same-document-transition">running same document transition</a><span>, in § 4.3</span>
-   <li><a href="#skip-the-page-transition">skip the page transition</a><span>, in § 6.4</span>
-   <li><a href="#dom-domtransition-skiptransition">skipTransition()</a><span>, in § 5.2.1</span>
-   <li><a href="#domtransition-tagged-elements">tagged elements</a><span>, in § 5.2</span>
-   <li><a href="#document-transition-suppressing-rendering">transition suppressing rendering</a><span>, in § 4.3</span>
-   <li><a href="#update-transition-dom">update transition DOM</a><span>, in § 6.6</span>
+   <li><a href="#document-active-dom-transition">active DOM transition</a><span>, in § 5.4</span>
+   <li><a href="#phases-after">after</a><span>, in § 5.1</span>
+   <li><a href="#animate-a-page-transition">animate a page transition</a><span>, in § 7.8</span>
+   <li><a href="#phases-before">before</a><span>, in § 5.1</span>
+   <li><a href="#call-the-dom-update-callback">call the DOM update callback</a><span>, in § 7.9</span>
+   <li><a href="#captured-element">captured element</a><span>, in § 5.3</span>
+   <li><a href="#capture-the-image">capture the image</a><span>, in § 7.5</span>
+   <li><a href="#capture-the-image">capturing the image</a><span>, in § 7.5</span>
+   <li><a href="#computing-the-interest-rectangle">compute the interest rectangle</a><span>, in § 7.7</span>
+   <li><a href="#computing-the-interest-rectangle">computing the interest rectangle</a><span>, in § 7.7</span>
+   <li><a href="#dom-document-createtransition">createTransition(init)</a><span>, in § 6.1.1</span>
+   <li><a href="#create-transition-pseudo-elements">create transition pseudo-elements</a><span>, in § 7.9</span>
+   <li><a href="#valdef-page-transition-tag-custom-ident">&lt;custom-ident></a><span>, in § 3.1</span>
+   <li><a href="#domtransition">DOMTransition</a><span>, in § 6.2</span>
+   <li><a href="#dictdef-domtransitioninit">DOMTransitionInit</a><span>, in § 6.1</span>
+   <li><a href="#domtransition-dom-update-callback">DOM update callback</a><span>, in § 6.2</span>
+   <li><a href="#dom-domtransition-domupdated">domUpdated</a><span>, in § 6.2</span>
+   <li><a href="#domtransition-dom-updated-promise">DOM updated promise</a><span>, in § 6.2</span>
+   <li><a href="#dom-domtransition-finished">finished</a><span>, in § 6.2</span>
+   <li><a href="#domtransition-finished-promise">finished promise</a><span>, in § 6.2</span>
+   <li><a href="#captured-element-incoming-element">incoming element</a><span>, in § 5.3</span>
+   <li><a href="#valdef-page-transition-tag-none">none</a><span>, in § 3.1</span>
+   <li><a href="#captured-element-outgoing-image">outgoing image</a><span>, in § 5.3</span>
+   <li><a href="#captured-element-outgoing-styles">outgoing styles</a><span>, in § 5.3</span>
+   <li><a href="#selectordef-page-transition">::page-transition</a><span>, in § 4</span>
+   <li><a href="#selectordef-page-transition-container-pt-tag-selector">::page-transition-container( &lt;pt-tag-selector> )</a><span>, in § 4</span>
+   <li><a href="#selectordef-page-transition-image-wrapper-pt-tag-selector">::page-transition-image-wrapper( &lt;pt-tag-selector> )</a><span>, in § 4</span>
+   <li><a href="#selectordef-page-transition-incoming-image-pt-tag-selector">::page-transition-incoming-image( &lt;pt-tag-selector> )</a><span>, in § 4</span>
+   <li><a href="#page-transition-layer">page-transition layer</a><span>, in § 5.2</span>
+   <li><a href="#selectordef-page-transition-outgoing-image-pt-tag-selector">::page-transition-outgoing-image( &lt;pt-tag-selector> )</a><span>, in § 4</span>
+   <li><a href="#page-transition-pseudo-elements">page-transition pseudo-elements</a><span>, in § 4</span>
+   <li><a href="#page-transition-tag">page transition tag</a><span>, in § 3.1</span>
+   <li><a href="#propdef-page-transition-tag">page-transition-tag</a><span>, in § 3.1</span>
+   <li><a href="#perform-an-outgoing-capture">perform an outgoing capture</a><span>, in § 7.3</span>
+   <li><a href="#perform-pending-transition-operations">perform pending transition operations</a><span>, in § 7.2</span>
+   <li><a href="#domtransition-phase">phase</a><span>, in § 6.2</span>
+   <li><a href="#phases">Phases</a><span>, in § 5.1</span>
+   <li><a href="#typedef-pt-tag-selector">&lt;pt-tag-selector></a><span>, in § 4</span>
+   <li><a href="#dom-domtransition-ready">ready</a><span>, in § 6.2</span>
+   <li><a href="#domtransition-ready-promise">ready promise</a><span>, in § 6.2</span>
+   <li><a href="#skip-the-page-transition">skip the page transition</a><span>, in § 7.4</span>
+   <li><a href="#dom-domtransition-skiptransition">skipTransition()</a><span>, in § 6.2.1</span>
+   <li><a href="#domtransition-tagged-elements">tagged elements</a><span>, in § 6.2</span>
+   <li><a href="#document-transition-suppressing-rendering">transition suppressing rendering</a><span>, in § 5.4</span>
+   <li><a href="#dom-domtransitioninit-updatedom">updateDOM</a><span>, in § 6.1</span>
+   <li><a href="#callbackdef-updatedomcallback">UpdateDOMCallback</a><span>, in § 6.1</span>
+   <li><a href="#update-transition-dom">update transition DOM</a><span>, in § 7.6</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-border-box">
    <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-border-box">3. Pseudo-elements</a> <a href="#ref-for-border-box①">(2)</a>
-    <li><a href="#ref-for-border-box②">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-border-box③">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-border-box④">6.9. Create transition pseudo-elements</a> <a href="#ref-for-border-box⑤">(2)</a> <a href="#ref-for-border-box⑥">(3)</a> <a href="#ref-for-border-box⑦">(4)</a>
+    <li><a href="#ref-for-border-box">4. Pseudo-elements</a> <a href="#ref-for-border-box①">(2)</a>
+    <li><a href="#ref-for-border-box②">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-border-box③">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-border-box④">7.9. Create transition pseudo-elements</a> <a href="#ref-for-border-box⑤">(2)</a> <a href="#ref-for-border-box⑥">(3)</a> <a href="#ref-for-border-box⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-fragmentation">
    <a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentation">6.3. Perform an outgoing capture</a> <a href="#ref-for-fragmentation①">(2)</a>
+    <li><a href="#ref-for-fragmentation">7.3. Perform an outgoing capture</a> <a href="#ref-for-fragmentation①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-computed-value">
    <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-computed-value">6.3. Perform an outgoing capture</a> <a href="#ref-for-computed-value①">(2)</a>
-    <li><a href="#ref-for-computed-value②">6.5. Capture the image</a>
-    <li><a href="#ref-for-computed-value③">6.9. Create transition pseudo-elements</a> <a href="#ref-for-computed-value④">(2)</a>
+    <li><a href="#ref-for-computed-value">7.3. Perform an outgoing capture</a> <a href="#ref-for-computed-value①">(2)</a>
+    <li><a href="#ref-for-computed-value②">7.5. Capture the image</a>
+    <li><a href="#ref-for-computed-value③">7.9. Create transition pseudo-elements</a> <a href="#ref-for-computed-value④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
    <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cascade-origin-ua">2.1. page-transition-tag</a>
-    <li><a href="#ref-for-cascade-origin-ua①">3. Pseudo-elements</a> <a href="#ref-for-cascade-origin-ua②">(2)</a> <a href="#ref-for-cascade-origin-ua③">(3)</a> <a href="#ref-for-cascade-origin-ua④">(4)</a> <a href="#ref-for-cascade-origin-ua⑤">(5)</a> <a href="#ref-for-cascade-origin-ua⑥">(6)</a> <a href="#ref-for-cascade-origin-ua⑦">(7)</a> <a href="#ref-for-cascade-origin-ua⑧">(8)</a>
-    <li><a href="#ref-for-cascade-origin-ua⑨">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-cascade-origin-ua①⓪">6.8. Animate a page transition</a> <a href="#ref-for-cascade-origin-ua①①">(2)</a> <a href="#ref-for-cascade-origin-ua①②">(3)</a> <a href="#ref-for-cascade-origin-ua①③">(4)</a> <a href="#ref-for-cascade-origin-ua①④">(5)</a>
-    <li><a href="#ref-for-cascade-origin-ua①⑤">6.9. Create transition pseudo-elements</a> <a href="#ref-for-cascade-origin-ua①⑥">(2)</a> <a href="#ref-for-cascade-origin-ua①⑦">(3)</a>
+    <li><a href="#ref-for-cascade-origin-ua">3.1. page-transition-tag</a>
+    <li><a href="#ref-for-cascade-origin-ua①">4. Pseudo-elements</a> <a href="#ref-for-cascade-origin-ua②">(2)</a> <a href="#ref-for-cascade-origin-ua③">(3)</a> <a href="#ref-for-cascade-origin-ua④">(4)</a> <a href="#ref-for-cascade-origin-ua⑤">(5)</a> <a href="#ref-for-cascade-origin-ua⑥">(6)</a> <a href="#ref-for-cascade-origin-ua⑦">(7)</a> <a href="#ref-for-cascade-origin-ua⑧">(8)</a>
+    <li><a href="#ref-for-cascade-origin-ua⑨">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-cascade-origin-ua①⓪">7.8. Animate a page transition</a> <a href="#ref-for-cascade-origin-ua①①">(2)</a> <a href="#ref-for-cascade-origin-ua①②">(3)</a> <a href="#ref-for-cascade-origin-ua①③">(4)</a> <a href="#ref-for-cascade-origin-ua①④">(5)</a>
+    <li><a href="#ref-for-cascade-origin-ua①⑤">7.9. Create transition pseudo-elements</a> <a href="#ref-for-cascade-origin-ua①⑥">(2)</a> <a href="#ref-for-cascade-origin-ua①⑦">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-layout-containment">
    <a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-layout-containment">6.3. Perform an outgoing capture</a> <a href="#ref-for-layout-containment①">(2)</a>
+    <li><a href="#ref-for-layout-containment">7.3. Perform an outgoing capture</a> <a href="#ref-for-layout-containment①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-replaced-element">
    <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-replaced-element">3. Pseudo-elements</a>
-    <li><a href="#ref-for-replaced-element①">6.9. Create transition pseudo-elements</a> <a href="#ref-for-replaced-element②">(2)</a>
+    <li><a href="#ref-for-replaced-element">4. Pseudo-elements</a>
+    <li><a href="#ref-for-replaced-element①">7.9. Create transition pseudo-elements</a> <a href="#ref-for-replaced-element②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-natural-dimensions">
    <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-natural-dimensions">3. Pseudo-elements</a>
+    <li><a href="#ref-for-natural-dimensions">4. Pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-element-not-rendered">
    <a href="https://drafts.csswg.org/css-images-4/#element-not-rendered">https://drafts.csswg.org/css-images-4/#element-not-rendered</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-element-not-rendered">6.3. Perform an outgoing capture</a> <a href="#ref-for-element-not-rendered①">(2)</a>
+    <li><a href="#ref-for-element-not-rendered">7.3. Perform an outgoing capture</a> <a href="#ref-for-element-not-rendered①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-object-view-box">
    <a href="https://drafts.csswg.org/css-images-4/#propdef-object-view-box">https://drafts.csswg.org/css-images-4/#propdef-object-view-box</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-object-view-box">6.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-object-view-box①">(2)</a>
-    <li><a href="#ref-for-propdef-object-view-box②">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-propdef-object-view-box③">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-object-view-box④">(2)</a> <a href="#ref-for-propdef-object-view-box⑤">(3)</a>
+    <li><a href="#ref-for-propdef-object-view-box">7.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-object-view-box①">(2)</a>
+    <li><a href="#ref-for-propdef-object-view-box②">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-propdef-object-view-box③">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-object-view-box④">(2)</a> <a href="#ref-for-propdef-object-view-box⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ink-overflow-region">
    <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow-region">https://drafts.csswg.org/css-overflow-3/#ink-overflow-region</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ink-overflow-region">6.7. Compute the interest rectangle</a>
+    <li><a href="#ref-for-ink-overflow-region">7.7. Compute the interest rectangle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ink-overflow-rectangle">
    <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#ink-overflow-rectangle</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ink-overflow-rectangle">6.5. Capture the image</a> <a href="#ref-for-ink-overflow-rectangle①">(2)</a>
-    <li><a href="#ref-for-ink-overflow-rectangle②">6.7. Compute the interest rectangle</a>
+    <li><a href="#ref-for-ink-overflow-rectangle">7.5. Capture the image</a> <a href="#ref-for-ink-overflow-rectangle①">(2)</a>
+    <li><a href="#ref-for-ink-overflow-rectangle②">7.7. Compute the interest rectangle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-inset">
    <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-funcdef-basic-shape-inset">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-funcdef-basic-shape-inset">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-xywh">
    <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-xywh">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-xywh</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-funcdef-basic-shape-xywh">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-funcdef-basic-shape-xywh">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-height">
    <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-height">3. Pseudo-elements</a>
-    <li><a href="#ref-for-propdef-height①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-propdef-height②">6.8. Animate a page transition</a> <a href="#ref-for-propdef-height③">(2)</a>
-    <li><a href="#ref-for-propdef-height④">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-height⑤">(2)</a>
+    <li><a href="#ref-for-propdef-height">4. Pseudo-elements</a>
+    <li><a href="#ref-for-propdef-height①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-propdef-height②">7.8. Animate a page transition</a> <a href="#ref-for-propdef-height③">(2)</a>
+    <li><a href="#ref-for-propdef-height④">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-height⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-width">
    <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-width">3. Pseudo-elements</a>
-    <li><a href="#ref-for-propdef-width①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-propdef-width②">6.8. Animate a page transition</a> <a href="#ref-for-propdef-width③">(2)</a>
-    <li><a href="#ref-for-propdef-width④">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-width⑤">(2)</a>
+    <li><a href="#ref-for-propdef-width">4. Pseudo-elements</a>
+    <li><a href="#ref-for-propdef-width①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-propdef-width②">7.8. Animate a page transition</a> <a href="#ref-for-propdef-width③">(2)</a>
+    <li><a href="#ref-for-propdef-width④">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-width⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-transform">
    <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-transform">3. Pseudo-elements</a>
-    <li><a href="#ref-for-propdef-transform①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-propdef-transform②">6.8. Animate a page transition</a> <a href="#ref-for-propdef-transform③">(2)</a>
-    <li><a href="#ref-for-propdef-transform④">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-transform⑤">(2)</a>
+    <li><a href="#ref-for-propdef-transform">4. Pseudo-elements</a>
+    <li><a href="#ref-for-propdef-transform①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-propdef-transform②">7.8. Animate a page transition</a> <a href="#ref-for-propdef-transform③">(2)</a>
+    <li><a href="#ref-for-propdef-transform④">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-transform⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-identifier-value">
    <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-identifier-value">2.1. page-transition-tag</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a>
-    <li><a href="#ref-for-identifier-value④">3. Pseudo-elements</a> <a href="#ref-for-identifier-value⑤">(2)</a> <a href="#ref-for-identifier-value⑥">(3)</a> <a href="#ref-for-identifier-value⑦">(4)</a>
+    <li><a href="#ref-for-identifier-value">3.1. page-transition-tag</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a>
+    <li><a href="#ref-for-identifier-value④">4. Pseudo-elements</a> <a href="#ref-for-identifier-value⑤">(2)</a> <a href="#ref-for-identifier-value⑥">(3)</a> <a href="#ref-for-identifier-value⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-comb-one">
    <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-comb-one">2.1. page-transition-tag</a>
-    <li><a href="#ref-for-comb-one①">3. Pseudo-elements</a>
+    <li><a href="#ref-for-comb-one">3.1. page-transition-tag</a>
+    <li><a href="#ref-for-comb-one①">4. Pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-direction">
    <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-direction">6.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-direction①">(2)</a>
-    <li><a href="#ref-for-propdef-direction②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-direction③">(2)</a> <a href="#ref-for-propdef-direction④">(3)</a>
+    <li><a href="#ref-for-propdef-direction">7.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-direction①">(2)</a>
+    <li><a href="#ref-for-propdef-direction②">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-direction③">(2)</a> <a href="#ref-for-propdef-direction④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
    <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-writing-mode">6.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
-    <li><a href="#ref-for-propdef-writing-mode②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-writing-mode③">(2)</a> <a href="#ref-for-propdef-writing-mode④">(3)</a>
+    <li><a href="#ref-for-propdef-writing-mode">7.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
+    <li><a href="#ref-for-propdef-writing-mode②">7.9. Create transition pseudo-elements</a> <a href="#ref-for-propdef-writing-mode③">(2)</a> <a href="#ref-for-propdef-writing-mode④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document">4.3. Additions to Document</a> <a href="#ref-for-document①">(2)</a>
-    <li><a href="#ref-for-document②">5.1. Additions to Document</a> <a href="#ref-for-document③">(2)</a>
-    <li><a href="#ref-for-document④">6.1. Monkey patch to rendering</a> <a href="#ref-for-document⑤">(2)</a>
-    <li><a href="#ref-for-document⑥">6.2. Perform pending transition operations</a>
+    <li><a href="#ref-for-document">5.4. Additions to Document</a> <a href="#ref-for-document①">(2)</a>
+    <li><a href="#ref-for-document②">6.1. Additions to Document</a> <a href="#ref-for-document③">(2)</a>
+    <li><a href="#ref-for-document④">7.1. Monkey patches to rendering</a> <a href="#ref-for-document⑤">(2)</a> <a href="#ref-for-document⑥">(3)</a>
+    <li><a href="#ref-for-document⑦">7.2. Perform pending transition operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-element">
    <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-element">6.3. Perform an outgoing capture</a> <a href="#ref-for-element①">(2)</a>
-    <li><a href="#ref-for-element②">6.5. Capture the image</a> <a href="#ref-for-element③">(2)</a>
-    <li><a href="#ref-for-element④">6.7. Compute the interest rectangle</a>
+    <li><a href="#ref-for-element">7.3. Perform an outgoing capture</a> <a href="#ref-for-element①">(2)</a>
+    <li><a href="#ref-for-element②">7.5. Capture the image</a> <a href="#ref-for-element③">(2)</a>
+    <li><a href="#ref-for-element④">7.7. Compute the interest rectangle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-tree-root">
    <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-concept-tree-root">4.1. The page-transition layer stacking layer</a> <a href="#termref-for-concept-tree-root">(2)</a>
-    <li><a href="#ref-for-concept-tree-root">6.3. Perform an outgoing capture</a> <a href="#ref-for-concept-tree-root①">(2)</a> <a href="#ref-for-concept-tree-root②">(3)</a> <a href="#ref-for-concept-tree-root③">(4)</a>
+    <li><a href="#termref-for-concept-tree-root">5.2. The page-transition layer stacking layer</a> <a href="#termref-for-concept-tree-root">(2)</a>
+    <li><a href="#ref-for-concept-tree-root">7.3. Perform an outgoing capture</a> <a href="#ref-for-concept-tree-root①">(2)</a> <a href="#ref-for-concept-tree-root②">(3)</a> <a href="#ref-for-concept-tree-root③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-shadow-including-descendant">
    <a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-including-descendant">6.5. Capture the image</a>
+    <li><a href="#ref-for-concept-shadow-including-descendant">7.5. Capture the image</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document-window">
    <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-window">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-concept-document-window①">6.3. Perform an outgoing capture</a> <a href="#ref-for-concept-document-window②">(2)</a>
-    <li><a href="#ref-for-concept-document-window③">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-concept-document-window④">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-concept-document-window⑤">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-concept-document-window">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-concept-document-window①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-concept-document-window②">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-concept-document-window③">7.6. Update transition DOM</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-fully-active">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">https://html.spec.whatwg.org/multipage/browsers.html#fully-active</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fully-active">6.1. Monkey patch to rendering</a>
+    <li><a href="#ref-for-fully-active">7.1. Monkey patches to rendering</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-queue-a-global-task">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-queue-a-global-task">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-relevant-global">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-concept-relevant-global①">6.3. Perform an outgoing capture</a> <a href="#ref-for-concept-relevant-global②">(2)</a> <a href="#ref-for-concept-relevant-global③">(3)</a>
-    <li><a href="#ref-for-concept-relevant-global④">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-concept-relevant-global⑤">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-concept-relevant-global⑥">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-concept-relevant-global">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-concept-relevant-global①">7.3. Perform an outgoing capture</a> <a href="#ref-for-concept-relevant-global②">(2)</a>
+    <li><a href="#ref-for-concept-relevant-global③">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-concept-relevant-global④">7.6. Update transition DOM</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-relevant-realm">5.1.1. createTransition()</a> <a href="#ref-for-concept-relevant-realm①">(2)</a> <a href="#ref-for-concept-relevant-realm②">(3)</a>
-    <li><a href="#ref-for-concept-relevant-realm③">5.2. The DOMTransition interface</a> <a href="#ref-for-concept-relevant-realm④">(2)</a> <a href="#ref-for-concept-relevant-realm⑤">(3)</a>
-    <li><a href="#ref-for-concept-relevant-realm⑥">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-concept-relevant-realm">6.1.1. createTransition()</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
+    <li><a href="#ref-for-concept-relevant-realm②">6.2. The DOMTransition interface</a> <a href="#ref-for-concept-relevant-realm③">(2)</a> <a href="#ref-for-concept-relevant-realm④">(3)</a>
+    <li><a href="#ref-for-concept-relevant-realm⑤">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-update-the-rendering">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-the-rendering">6.1. Monkey patch to rendering</a> <a href="#ref-for-update-the-rendering①">(2)</a>
+    <li><a href="#ref-for-update-the-rendering">7.1. Monkey patches to rendering</a> <a href="#ref-for-update-the-rendering①">(2)</a> <a href="#ref-for-update-the-rendering②">(3)</a> <a href="#ref-for-update-the-rendering③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-set-append">
    <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-set-append">6.3. Perform an outgoing capture</a> <a href="#ref-for-set-append①">(2)</a>
+    <li><a href="#ref-for-set-append">7.3. Perform an outgoing capture</a> <a href="#ref-for-set-append①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-assert①">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-assert②">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-assert③">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-assert">7.4. Skip the page transition</a> <a href="#ref-for-assert①">(2)</a>
+    <li><a href="#ref-for-assert②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-contain">
    <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-contain">6.3. Perform an outgoing capture</a> <a href="#ref-for-list-contain①">(2)</a>
+    <li><a href="#ref-for-list-contain">7.3. Perform an outgoing capture</a> <a href="#ref-for-list-contain①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-iteration-continue">
    <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-iteration-continue">6.3. Perform an outgoing capture</a> <a href="#ref-for-iteration-continue①">(2)</a>
+    <li><a href="#ref-for-iteration-continue">7.3. Perform an outgoing capture</a> <a href="#ref-for-iteration-continue①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-map-exists">
    <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-map-exists">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-map-exists">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-map-iterate">
    <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-map-iterate">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-map-iterate①">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-map-iterate②">6.9. Create transition pseudo-elements</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-map-iterate">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-map-iterate①">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-map-iterate②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-map">
    <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ordered-map">5.2. The DOMTransition interface</a> <a href="#ref-for-ordered-map①">(2)</a>
+    <li><a href="#ref-for-ordered-map">6.2. The DOMTransition interface</a> <a href="#ref-for-ordered-map①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-set">
    <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ordered-set">6.3. Perform an outgoing capture</a> <a href="#ref-for-ordered-set①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list-size">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-ordered-set">7.3. Perform an outgoing capture</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-struct">
    <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-struct">4.2. Captured elements</a>
+    <li><a href="#ref-for-struct">5.3. Captured elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-x">
    <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-x">3. Pseudo-elements</a> <a href="#ref-for-x①">(2)</a>
+    <li><a href="#ref-for-x">4. Pseudo-elements</a> <a href="#ref-for-x①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-originating-element">
    <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-originating-element">3. Pseudo-elements</a> <a href="#ref-for-originating-element①">(2)</a> <a href="#ref-for-originating-element②">(3)</a> <a href="#ref-for-originating-element③">(4)</a> <a href="#ref-for-originating-element④">(5)</a>
+    <li><a href="#ref-for-originating-element">4. Pseudo-elements</a> <a href="#ref-for-originating-element①">(2)</a> <a href="#ref-for-originating-element②">(3)</a> <a href="#ref-for-originating-element③">(4)</a> <a href="#ref-for-originating-element④">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-pseudo-element">
    <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-pseudo-element">6.3. Perform an outgoing capture</a> <a href="#ref-for-pseudo-element①">(2)</a>
-    <li><a href="#ref-for-pseudo-element②">6.5. Capture the image</a>
+    <li><a href="#ref-for-pseudo-element">7.3. Perform an outgoing capture</a> <a href="#ref-for-pseudo-element①">(2)</a>
+    <li><a href="#ref-for-pseudo-element②">7.5. Capture the image</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-type-selector">
    <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-type-selector">3. Pseudo-elements</a>
+    <li><a href="#ref-for-type-selector">4. Pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-aborterror">
    <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-aborterror">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-aborterror①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-aborterror">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-aborterror①">6.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMException">
    <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMException">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-idl-DOMException①">5.2.1. skipTransition()</a>
-    <li><a href="#ref-for-idl-DOMException②">6.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException③">(2)</a> <a href="#ref-for-idl-DOMException④">(3)</a>
+    <li><a href="#ref-for-idl-DOMException">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-idl-DOMException①">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-idl-DOMException②">7.3. Perform an outgoing capture</a> <a href="#ref-for-idl-DOMException③">(2)</a> <a href="#ref-for-idl-DOMException④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
    <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidstateerror">6.3. Perform an outgoing capture</a> <a href="#ref-for-invalidstateerror①">(2)</a>
+    <li><a href="#ref-for-invalidstateerror">7.3. Perform an outgoing capture</a> <a href="#ref-for-invalidstateerror①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
    <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-promise">5.1. Additions to Document</a>
-    <li><a href="#ref-for-idl-promise①">5.2. The DOMTransition interface</a> <a href="#ref-for-idl-promise②">(2)</a> <a href="#ref-for-idl-promise③">(3)</a> <a href="#ref-for-idl-promise④">(4)</a> <a href="#ref-for-idl-promise⑤">(5)</a> <a href="#ref-for-idl-promise⑥">(6)</a>
+    <li><a href="#ref-for-idl-promise">6.1. Additions to Document</a>
+    <li><a href="#ref-for-idl-promise①">6.2. The DOMTransition interface</a> <a href="#ref-for-idl-promise②">(2)</a> <a href="#ref-for-idl-promise③">(3)</a> <a href="#ref-for-idl-promise④">(4)</a> <a href="#ref-for-idl-promise⑤">(5)</a> <a href="#ref-for-idl-promise⑥">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-timeouterror">
    <a href="https://webidl.spec.whatwg.org/#timeouterror">https://webidl.spec.whatwg.org/#timeouterror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-timeouterror">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-timeouterror">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-new-promise">
    <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-a-new-promise">5.2. The DOMTransition interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
+    <li><a href="#ref-for-a-new-promise">6.2. The DOMTransition interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-any">
    <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-any">5.1. Additions to Document</a>
+    <li><a href="#ref-for-idl-any">6.1. Additions to Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-getter-steps">
    <a href="https://webidl.spec.whatwg.org/#getter-steps">https://webidl.spec.whatwg.org/#getter-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-getter-steps">5.2. The DOMTransition interface</a> <a href="#ref-for-getter-steps①">(2)</a> <a href="#ref-for-getter-steps②">(3)</a>
+    <li><a href="#ref-for-getter-steps">6.2. The DOMTransition interface</a> <a href="#ref-for-getter-steps①">(2)</a> <a href="#ref-for-getter-steps②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
    <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invoke-a-callback-function">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-invoke-a-callback-function">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-method-steps">
    <a href="https://webidl.spec.whatwg.org/#method-steps">https://webidl.spec.whatwg.org/#method-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-method-steps">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-method-steps①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-method-steps">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-method-steps①">6.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
    <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-reject">
    <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reject">6.4. Skip the page transition</a> <a href="#ref-for-reject①">(2)</a>
-    <li><a href="#ref-for-reject②">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-reject">7.4. Skip the page transition</a> <a href="#ref-for-reject①">(2)</a>
+    <li><a href="#ref-for-reject②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
    <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resolve">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-resolve①">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-resolve②">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-resolve">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-resolve①">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-resolve②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-this">
    <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-this">5.1.1. createTransition()</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a>
-    <li><a href="#ref-for-this④">5.2. The DOMTransition interface</a> <a href="#ref-for-this⑤">(2)</a> <a href="#ref-for-this⑥">(3)</a> <a href="#ref-for-this⑦">(4)</a> <a href="#ref-for-this⑧">(5)</a> <a href="#ref-for-this⑨">(6)</a>
-    <li><a href="#ref-for-this①⓪">5.2.1. skipTransition()</a> <a href="#ref-for-this①①">(2)</a>
+    <li><a href="#ref-for-this">6.1.1. createTransition()</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
+    <li><a href="#ref-for-this③">6.2. The DOMTransition interface</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a> <a href="#ref-for-this⑥">(4)</a> <a href="#ref-for-this⑦">(5)</a> <a href="#ref-for-this⑧">(6)</a>
+    <li><a href="#ref-for-this⑨">6.2.1. skipTransition()</a> <a href="#ref-for-this①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
    <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-undefined">5.2. The DOMTransition interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
+    <li><a href="#ref-for-idl-undefined">6.2. The DOMTransition interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2409,10 +2399,8 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
      <li><span class="dfn-paneled" id="term-for-iteration-continue">continue</span>
      <li><span class="dfn-paneled" id="term-for-map-exists">exist</span>
      <li><span class="dfn-paneled" id="term-for-map-iterate">for each <small>(for map)</small></span>
-     <li><span class="dfn-paneled" id="term-for-list">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-map">map</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set">set</span>
-     <li><span class="dfn-paneled" id="term-for-list-size">size</span>
      <li><span class="dfn-paneled" id="term-for-struct">struct</span>
     </ul>
    <li>
@@ -2526,10 +2514,10 @@ will cause the view box to coincide with <a data-link-type="dfn" href="#captured
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-domtransitioninit"><code><c- g>DOMTransitionInit</c-></code></a> {
-    <a data-link-type="idl-name" href="#callbackdef-changedomcallback"><c- n>ChangeDOMCallback</c-></a> <a data-type="ChangeDOMCallback " href="#dom-domtransitioninit-changedom"><code><c- g>changeDOM</c-></code></a>;
+    <a data-link-type="idl-name" href="#callbackdef-updatedomcallback"><c- n>UpdateDOMCallback</c-></a> <a data-type="UpdateDOMCallback " href="#dom-domtransitioninit-updatedom"><code><c- g>updateDOM</c-></code></a>;
 };
 
-<c- b>callback</c-> <a href="#callbackdef-changedomcallback"><code><c- g>ChangeDOMCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();
+<c- b>callback</c-> <a href="#callbackdef-updatedomcallback"><code><c- g>UpdateDOMCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>> ();
 
 <c- b>interface</c-> <a href="#domtransition"><code><c- g>DOMTransition</c-></code></a> {
     <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-domtransition-skiptransition"><c- g>skipTransition</c-></a>();
@@ -2554,18 +2542,17 @@ layer elements has filters and effects coming from the root element’s style? <
    <div class="issue"> The type of "image" needs to be linked or defined. <a class="issue-return" href="#issue-4e3c66a5" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "a set of styles" needs to be linked or defined. <a class="issue-return" href="#issue-ae4536a8" title="Jump to section">↵</a></div>
    <div class="issue"> The type of "element" needs to be linked or defined. <a class="issue-return" href="#issue-e6615d56" title="Jump to section">↵</a></div>
-   <div class="issue"> The link for "paint order" doesn’t seem right.
-    Is there a more canonical definition? <a class="issue-return" href="#issue-ad1ca140" title="Jump to section">↵</a></div>
-   <div class="issue"> This needs proper types. <a class="issue-return" href="#issue-f121180b" title="Jump to section">↵</a></div>
-   <div class="issue"> Further clarify this behavior. Lifecycle updates can still be triggered
+   <div class="issue"> Define this behavior. Lifecycle updates can still be triggered
 via script APIs which query style or layout information but no visual updates
-are presented to the user. Is this the same behavior as render-blocking? <a class="issue-return" href="#issue-edbf8829" title="Jump to section">↵</a></div>
+are presented to the user. Is this the same behavior as render-blocking? <a class="issue-return" href="#issue-ac37ca1e" title="Jump to section">↵</a></div>
    <div class="issue"> How should input be handled when in this state? The last frame presented
 to the user will not reflect the DOM state as it asynchronously switches to
 the new version. <a class="issue-return" href="#issue-f6dfdcaa" title="Jump to section">↵</a></div>
    <div class="issue"> The link for "paint order" doesn’t seem right.
+    Is there a more canonical definition? <a class="issue-return" href="#issue-ad1ca140" title="Jump to section">↵</a></div>
+   <div class="issue"> This needs proper types. <a class="issue-return" href="#issue-f121180b" title="Jump to section">↵</a></div>
+   <div class="issue"> The link for "paint order" doesn’t seem right.
     Is there a more canonical definition? <a class="issue-return" href="#issue-ad1ca140①" title="Jump to section">↵</a></div>
-   <div class="issue"> "suppressing rendering opportunities" needs to be linked/defined. <a class="issue-return" href="#issue-2b1a73c3" title="Jump to section">↵</a></div>
    <div class="issue"> There needs to be a definition/link for "remove". <a class="issue-return" href="#issue-80506344" title="Jump to section">↵</a></div>
    <div class="issue"> There needs to be a definition/link for "associated". <a class="issue-return" href="#issue-cc250ace" title="Jump to section">↵</a></div>
    <div class="issue"> Refactor this so the algorithm takes a set of elements that will be captured. This centralizes the logic for deciding if an element should be included or not. <a class="issue-return" href="#issue-2bfbc0f2" title="Jump to section">↵</a></div>
@@ -2590,316 +2577,326 @@ get c0 continuity. <a class="issue-return" href="#issue-70e412c9" title="Jump to
   <aside class="dfn-panel" data-for="propdef-page-transition-tag">
    <b><a href="#propdef-page-transition-tag">#propdef-page-transition-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-page-transition-tag">2.1. page-transition-tag</a> <a href="#ref-for-propdef-page-transition-tag①">(2)</a>
-    <li><a href="#ref-for-propdef-page-transition-tag②">6.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-page-transition-tag③">(2)</a> <a href="#ref-for-propdef-page-transition-tag④">(3)</a>
-    <li><a href="#ref-for-propdef-page-transition-tag⑤">6.5. Capture the image</a>
+    <li><a href="#ref-for-propdef-page-transition-tag">3.1. page-transition-tag</a> <a href="#ref-for-propdef-page-transition-tag①">(2)</a>
+    <li><a href="#ref-for-propdef-page-transition-tag②">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-propdef-page-transition-tag③">7.3. Perform an outgoing capture</a> <a href="#ref-for-propdef-page-transition-tag④">(2)</a>
+    <li><a href="#ref-for-propdef-page-transition-tag⑤">7.5. Capture the image</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-page-transition-tag-none">
    <b><a href="#valdef-page-transition-tag-none">#valdef-page-transition-tag-none</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-page-transition-tag-none">6.3. Perform an outgoing capture</a> <a href="#ref-for-valdef-page-transition-tag-none①">(2)</a>
-    <li><a href="#ref-for-valdef-page-transition-tag-none②">6.5. Capture the image</a>
+    <li><a href="#ref-for-valdef-page-transition-tag-none">7.3. Perform an outgoing capture</a> <a href="#ref-for-valdef-page-transition-tag-none①">(2)</a>
+    <li><a href="#ref-for-valdef-page-transition-tag-none②">7.5. Capture the image</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="page-transition-tag">
    <b><a href="#page-transition-tag">#page-transition-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-page-transition-tag">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-page-transition-tag">6.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="page-transition-pseudo-elements">
    <b><a href="#page-transition-pseudo-elements">#page-transition-pseudo-elements</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-page-transition-pseudo-elements">3. Pseudo-elements</a> <a href="#ref-for-page-transition-pseudo-elements①">(2)</a> <a href="#ref-for-page-transition-pseudo-elements②">(3)</a> <a href="#ref-for-page-transition-pseudo-elements③">(4)</a>
-    <li><a href="#ref-for-page-transition-pseudo-elements④">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-page-transition-pseudo-elements⑤">6.6. Update transition DOM</a> <a href="#ref-for-page-transition-pseudo-elements⑥">(2)</a> <a href="#ref-for-page-transition-pseudo-elements⑦">(3)</a>
+    <li><a href="#ref-for-page-transition-pseudo-elements">4. Pseudo-elements</a> <a href="#ref-for-page-transition-pseudo-elements①">(2)</a> <a href="#ref-for-page-transition-pseudo-elements②">(3)</a> <a href="#ref-for-page-transition-pseudo-elements③">(4)</a>
+    <li><a href="#ref-for-page-transition-pseudo-elements④">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-page-transition-pseudo-elements⑤">7.6. Update transition DOM</a> <a href="#ref-for-page-transition-pseudo-elements⑥">(2)</a> <a href="#ref-for-page-transition-pseudo-elements⑦">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedef-pt-tag-selector">
    <b><a href="#typedef-pt-tag-selector">#typedef-pt-tag-selector</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedef-pt-tag-selector">3. Pseudo-elements</a> <a href="#ref-for-typedef-pt-tag-selector①">(2)</a> <a href="#ref-for-typedef-pt-tag-selector②">(3)</a> <a href="#ref-for-typedef-pt-tag-selector③">(4)</a> <a href="#ref-for-typedef-pt-tag-selector④">(5)</a> <a href="#ref-for-typedef-pt-tag-selector⑤">(6)</a>
+    <li><a href="#ref-for-typedef-pt-tag-selector">4. Pseudo-elements</a> <a href="#ref-for-typedef-pt-tag-selector①">(2)</a> <a href="#ref-for-typedef-pt-tag-selector②">(3)</a> <a href="#ref-for-typedef-pt-tag-selector③">(4)</a> <a href="#ref-for-typedef-pt-tag-selector④">(5)</a> <a href="#ref-for-typedef-pt-tag-selector⑤">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="selectordef-page-transition">
    <b><a href="#selectordef-page-transition">#selectordef-page-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-selectordef-page-transition">3. Pseudo-elements</a> <a href="#ref-for-selectordef-page-transition①">(2)</a>
-    <li><a href="#ref-for-selectordef-page-transition②">4.1. The page-transition layer stacking layer</a>
-    <li><a href="#ref-for-selectordef-page-transition③">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-selectordef-page-transition">4. Pseudo-elements</a> <a href="#ref-for-selectordef-page-transition①">(2)</a>
+    <li><a href="#ref-for-selectordef-page-transition②">5.2. The page-transition layer stacking layer</a>
+    <li><a href="#ref-for-selectordef-page-transition③">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="selectordef-page-transition-container-pt-tag-selector">
    <b><a href="#selectordef-page-transition-container-pt-tag-selector">#selectordef-page-transition-container-pt-tag-selector</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-selectordef-page-transition-container-pt-tag-selector">3. Pseudo-elements</a>
+    <li><a href="#ref-for-selectordef-page-transition-container-pt-tag-selector">4. Pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="selectordef-page-transition-image-wrapper-pt-tag-selector">
    <b><a href="#selectordef-page-transition-image-wrapper-pt-tag-selector">#selectordef-page-transition-image-wrapper-pt-tag-selector</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-selectordef-page-transition-image-wrapper-pt-tag-selector">3. Pseudo-elements</a>
+    <li><a href="#ref-for-selectordef-page-transition-image-wrapper-pt-tag-selector">4. Pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="selectordef-page-transition-outgoing-image-pt-tag-selector">
    <b><a href="#selectordef-page-transition-outgoing-image-pt-tag-selector">#selectordef-page-transition-outgoing-image-pt-tag-selector</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-selectordef-page-transition-outgoing-image-pt-tag-selector">3. Pseudo-elements</a>
+    <li><a href="#ref-for-selectordef-page-transition-outgoing-image-pt-tag-selector">4. Pseudo-elements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="phases">
+   <b><a href="#phases">#phases</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-phases">5.1. Phases</a>
+    <li><a href="#ref-for-phases①">6.2. The DOMTransition interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="phases-before">
+   <b><a href="#phases-before">#phases-before</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-phases-before">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-phases-before①">7.9. Create transition pseudo-elements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="phases-after">
+   <b><a href="#phases-after">#phases-after</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-phases-after">7.4. Skip the page transition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="page-transition-layer">
    <b><a href="#page-transition-layer">#page-transition-layer</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-page-transition-layer">4.1. The page-transition layer stacking layer</a>
+    <li><a href="#ref-for-page-transition-layer">5.2. The page-transition layer stacking layer</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="captured-element">
    <b><a href="#captured-element">#captured-element</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-captured-element">4.2. Captured elements</a>
-    <li><a href="#ref-for-captured-element①">5.2. The DOMTransition interface</a>
-    <li><a href="#ref-for-captured-element②">6.3. Perform an outgoing capture</a> <a href="#ref-for-captured-element③">(2)</a>
+    <li><a href="#ref-for-captured-element">5.3. Captured elements</a>
+    <li><a href="#ref-for-captured-element①">6.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-captured-element②">7.3. Perform an outgoing capture</a> <a href="#ref-for-captured-element③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="captured-element-outgoing-image">
    <b><a href="#captured-element-outgoing-image">#captured-element-outgoing-image</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-captured-element-outgoing-image">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-captured-element-outgoing-image①">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-captured-element-outgoing-image②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-outgoing-image③">(2)</a>
+    <li><a href="#ref-for-captured-element-outgoing-image">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-captured-element-outgoing-image①">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-captured-element-outgoing-image②">7.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-outgoing-image③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="captured-element-outgoing-styles">
    <b><a href="#captured-element-outgoing-styles">#captured-element-outgoing-styles</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-captured-element-outgoing-styles">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-captured-element-outgoing-styles①">6.8. Animate a page transition</a> <a href="#ref-for-captured-element-outgoing-styles②">(2)</a> <a href="#ref-for-captured-element-outgoing-styles③">(3)</a>
-    <li><a href="#ref-for-captured-element-outgoing-styles④">6.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-outgoing-styles⑤">(2)</a> <a href="#ref-for-captured-element-outgoing-styles⑥">(3)</a> <a href="#ref-for-captured-element-outgoing-styles⑦">(4)</a> <a href="#ref-for-captured-element-outgoing-styles⑧">(5)</a> <a href="#ref-for-captured-element-outgoing-styles⑨">(6)</a>
+    <li><a href="#ref-for-captured-element-outgoing-styles">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-captured-element-outgoing-styles①">7.8. Animate a page transition</a> <a href="#ref-for-captured-element-outgoing-styles②">(2)</a> <a href="#ref-for-captured-element-outgoing-styles③">(3)</a>
+    <li><a href="#ref-for-captured-element-outgoing-styles④">7.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-outgoing-styles⑤">(2)</a> <a href="#ref-for-captured-element-outgoing-styles⑥">(3)</a> <a href="#ref-for-captured-element-outgoing-styles⑦">(4)</a> <a href="#ref-for-captured-element-outgoing-styles⑧">(5)</a> <a href="#ref-for-captured-element-outgoing-styles⑨">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="captured-element-incoming-element">
    <b><a href="#captured-element-incoming-element">#captured-element-incoming-element</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-captured-element-incoming-element">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-captured-element-incoming-element①">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-captured-element-incoming-element②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-incoming-element③">(2)</a> <a href="#ref-for-captured-element-incoming-element④">(3)</a> <a href="#ref-for-captured-element-incoming-element⑤">(4)</a> <a href="#ref-for-captured-element-incoming-element⑥">(5)</a> <a href="#ref-for-captured-element-incoming-element⑦">(6)</a> <a href="#ref-for-captured-element-incoming-element⑧">(7)</a> <a href="#ref-for-captured-element-incoming-element⑨">(8)</a> <a href="#ref-for-captured-element-incoming-element①⓪">(9)</a>
+    <li><a href="#ref-for-captured-element-incoming-element">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-captured-element-incoming-element①">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-captured-element-incoming-element②">7.9. Create transition pseudo-elements</a> <a href="#ref-for-captured-element-incoming-element③">(2)</a> <a href="#ref-for-captured-element-incoming-element④">(3)</a> <a href="#ref-for-captured-element-incoming-element⑤">(4)</a> <a href="#ref-for-captured-element-incoming-element⑥">(5)</a> <a href="#ref-for-captured-element-incoming-element⑦">(6)</a> <a href="#ref-for-captured-element-incoming-element⑧">(7)</a> <a href="#ref-for-captured-element-incoming-element⑨">(8)</a> <a href="#ref-for-captured-element-incoming-element①⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-pending-same-document-transition-outgoing-capture">
-   <b><a href="#document-pending-same-document-transition-outgoing-capture">#document-pending-same-document-transition-outgoing-capture</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-active-dom-transition">
+   <b><a href="#document-active-dom-transition">#document-active-dom-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture">5.1.1. createTransition()</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture①">(2)</a>
-    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture②">6.2. Perform pending transition operations</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture③">(2)</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture④">(3)</a>
-    <li><a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑤">6.4. Skip the page transition</a> <a href="#ref-for-document-pending-same-document-transition-outgoing-capture⑥">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="document-running-same-document-transition">
-   <b><a href="#document-running-same-document-transition">#document-running-same-document-transition</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-document-running-same-document-transition">6.2. Perform pending transition operations</a> <a href="#ref-for-document-running-same-document-transition①">(2)</a>
-    <li><a href="#ref-for-document-running-same-document-transition②">6.4. Skip the page transition</a> <a href="#ref-for-document-running-same-document-transition③">(2)</a>
-    <li><a href="#ref-for-document-running-same-document-transition④">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-document-running-same-document-transition⑤">6.8. Animate a page transition</a> <a href="#ref-for-document-running-same-document-transition⑥">(2)</a>
+    <li><a href="#ref-for-document-active-dom-transition">6.1.1. createTransition()</a> <a href="#ref-for-document-active-dom-transition①">(2)</a> <a href="#ref-for-document-active-dom-transition②">(3)</a> <a href="#ref-for-document-active-dom-transition③">(4)</a>
+    <li><a href="#ref-for-document-active-dom-transition④">7.2. Perform pending transition operations</a> <a href="#ref-for-document-active-dom-transition⑤">(2)</a> <a href="#ref-for-document-active-dom-transition⑥">(3)</a> <a href="#ref-for-document-active-dom-transition⑦">(4)</a> <a href="#ref-for-document-active-dom-transition⑧">(5)</a>
+    <li><a href="#ref-for-document-active-dom-transition⑨">7.4. Skip the page transition</a> <a href="#ref-for-document-active-dom-transition①⓪">(2)</a>
+    <li><a href="#ref-for-document-active-dom-transition①①">7.6. Update transition DOM</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="document-transition-suppressing-rendering">
    <b><a href="#document-transition-suppressing-rendering">#document-transition-suppressing-rendering</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-transition-suppressing-rendering">6.3. Perform an outgoing capture</a> <a href="#ref-for-document-transition-suppressing-rendering①">(2)</a>
-    <li><a href="#ref-for-document-transition-suppressing-rendering②">6.4. Skip the page transition</a> <a href="#ref-for-document-transition-suppressing-rendering③">(2)</a>
+    <li><a href="#ref-for-document-transition-suppressing-rendering">7.1. Monkey patches to rendering</a>
+    <li><a href="#ref-for-document-transition-suppressing-rendering①">7.3. Perform an outgoing capture</a> <a href="#ref-for-document-transition-suppressing-rendering②">(2)</a>
+    <li><a href="#ref-for-document-transition-suppressing-rendering③">7.4. Skip the page transition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-domtransitioninit">
    <b><a href="#dictdef-domtransitioninit">#dictdef-domtransitioninit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-domtransitioninit">5.1. Additions to Document</a>
+    <li><a href="#ref-for-dictdef-domtransitioninit">6.1. Additions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtransitioninit-changedom">
-   <b><a href="#dom-domtransitioninit-changedom">#dom-domtransitioninit-changedom</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-domtransitioninit-updatedom">
+   <b><a href="#dom-domtransitioninit-updatedom">#dom-domtransitioninit-updatedom</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domtransitioninit-changedom">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-dom-domtransitioninit-updatedom">2. Transitions as an enhancement</a>
+    <li><a href="#ref-for-dom-domtransitioninit-updatedom①">6.1.1. createTransition()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-changedomcallback">
-   <b><a href="#callbackdef-changedomcallback">#callbackdef-changedomcallback</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="callbackdef-updatedomcallback">
+   <b><a href="#callbackdef-updatedomcallback">#callbackdef-updatedomcallback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-callbackdef-changedomcallback">5.1. Additions to Document</a>
-    <li><a href="#ref-for-callbackdef-changedomcallback①">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-callbackdef-updatedomcallback">6.1. Additions to Document</a>
+    <li><a href="#ref-for-callbackdef-updatedomcallback①">6.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-document-createtransition">
    <b><a href="#dom-document-createtransition">#dom-document-createtransition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-createtransition">5.1. Additions to Document</a>
-    <li><a href="#ref-for-dom-document-createtransition①">5.1.1. createTransition()</a>
+    <li><a href="#ref-for-dom-document-createtransition">6.1. Additions to Document</a>
+    <li><a href="#ref-for-dom-document-createtransition①">6.1.1. createTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="domtransition">
    <b><a href="#domtransition">#domtransition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition">4.3. Additions to Document</a> <a href="#ref-for-domtransition①">(2)</a> <a href="#ref-for-domtransition②">(3)</a>
-    <li><a href="#ref-for-domtransition③">5.1. Additions to Document</a>
-    <li><a href="#ref-for-domtransition④">5.1.1. createTransition()</a> <a href="#ref-for-domtransition⑤">(2)</a>
-    <li><a href="#ref-for-domtransition⑥">5.2. The DOMTransition interface</a> <a href="#ref-for-domtransition⑦">(2)</a> <a href="#ref-for-domtransition⑧">(3)</a>
-    <li><a href="#ref-for-domtransition⑨">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-domtransition①⓪">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-domtransition①①">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-domtransition①②">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-domtransition①③">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition①④">(2)</a>
+    <li><a href="#ref-for-domtransition">5.4. Additions to Document</a>
+    <li><a href="#ref-for-domtransition①">6.1. Additions to Document</a>
+    <li><a href="#ref-for-domtransition②">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-domtransition③">6.2. The DOMTransition interface</a> <a href="#ref-for-domtransition④">(2)</a> <a href="#ref-for-domtransition⑤">(3)</a>
+    <li><a href="#ref-for-domtransition⑥">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition⑦">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition⑧">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition⑨">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-domtransition①⓪">7.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition①①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-domtransition-finished">
    <b><a href="#dom-domtransition-finished">#dom-domtransition-finished</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domtransition-finished">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-dom-domtransition-finished">6.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-domtransition-ready">
    <b><a href="#dom-domtransition-ready">#dom-domtransition-ready</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domtransition-ready">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-dom-domtransition-ready">6.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-domtransition-domupdated">
    <b><a href="#dom-domtransition-domupdated">#dom-domtransition-domupdated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domtransition-domupdated">5.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-dom-domtransition-domupdated">6.2. The DOMTransition interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="domtransition-tagged-elements">
    <b><a href="#domtransition-tagged-elements">#domtransition-tagged-elements</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-tagged-elements">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-domtransition-tagged-elements①">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-domtransition-tagged-elements②">6.8. Animate a page transition</a>
-    <li><a href="#ref-for-domtransition-tagged-elements③">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-domtransition-tagged-elements">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-tagged-elements①">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition-tagged-elements②">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-domtransition-tagged-elements③">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domtransition-concluded">
-   <b><a href="#domtransition-concluded">#domtransition-concluded</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="domtransition-phase">
+   <b><a href="#domtransition-phase">#domtransition-phase</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-concluded">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-domtransition-concluded①">5.2.1. skipTransition()</a>
-    <li><a href="#ref-for-domtransition-concluded②">6.3. Perform an outgoing capture</a> <a href="#ref-for-domtransition-concluded③">(2)</a> <a href="#ref-for-domtransition-concluded④">(3)</a>
-    <li><a href="#ref-for-domtransition-concluded⑤">6.4. Skip the page transition</a> <a href="#ref-for-domtransition-concluded⑥">(2)</a>
-    <li><a href="#ref-for-domtransition-concluded⑦">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition-phase">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-domtransition-phase①">7.2. Perform pending transition operations</a> <a href="#ref-for-domtransition-phase②">(2)</a>
+    <li><a href="#ref-for-domtransition-phase③">7.3. Perform an outgoing capture</a> <a href="#ref-for-domtransition-phase④">(2)</a> <a href="#ref-for-domtransition-phase⑤">(3)</a> <a href="#ref-for-domtransition-phase⑥">(4)</a>
+    <li><a href="#ref-for-domtransition-phase⑦">7.4. Skip the page transition</a> <a href="#ref-for-domtransition-phase⑧">(2)</a> <a href="#ref-for-domtransition-phase⑨">(3)</a> <a href="#ref-for-domtransition-phase①⓪">(4)</a>
+    <li><a href="#ref-for-domtransition-phase①①">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition-phase①②">7.8. Animate a page transition</a>
+    <li><a href="#ref-for-domtransition-phase①③">7.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-phase①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domtransition-dom-change-callback">
-   <b><a href="#domtransition-dom-change-callback">#domtransition-dom-change-callback</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="domtransition-dom-update-callback">
+   <b><a href="#domtransition-dom-update-callback">#domtransition-dom-update-callback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-dom-change-callback">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-domtransition-dom-change-callback①">6.9. Create transition pseudo-elements</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="domtransition-dom-change-callback-called">
-   <b><a href="#domtransition-dom-change-callback-called">#domtransition-dom-change-callback-called</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-domtransition-dom-change-callback-called">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-domtransition-dom-change-callback-called①">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-dom-change-callback-called②">(2)</a>
+    <li><a href="#ref-for-domtransition-dom-update-callback">6.1.1. createTransition()</a> <a href="#ref-for-domtransition-dom-update-callback①">(2)</a>
+    <li><a href="#ref-for-domtransition-dom-update-callback②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="domtransition-ready-promise">
    <b><a href="#domtransition-ready-promise">#domtransition-ready-promise</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-ready-promise">5.2. The DOMTransition interface</a>
-    <li><a href="#ref-for-domtransition-ready-promise①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-domtransition-ready-promise②">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition-ready-promise">6.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-ready-promise①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-ready-promise②">7.4. Skip the page transition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="domtransition-dom-updated-promise">
    <b><a href="#domtransition-dom-updated-promise">#domtransition-dom-updated-promise</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-dom-updated-promise">5.2. The DOMTransition interface</a>
-    <li><a href="#ref-for-domtransition-dom-updated-promise①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-domtransition-dom-updated-promise②">6.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-dom-updated-promise③">(2)</a>
+    <li><a href="#ref-for-domtransition-dom-updated-promise">6.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-dom-updated-promise①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-domtransition-dom-updated-promise②">7.9. Create transition pseudo-elements</a> <a href="#ref-for-domtransition-dom-updated-promise③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="domtransition-finished-promise">
    <b><a href="#domtransition-finished-promise">#domtransition-finished-promise</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domtransition-finished-promise">5.2. The DOMTransition interface</a>
-    <li><a href="#ref-for-domtransition-finished-promise①">6.4. Skip the page transition</a>
-    <li><a href="#ref-for-domtransition-finished-promise②">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-domtransition-finished-promise">6.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-domtransition-finished-promise①">7.4. Skip the page transition</a>
+    <li><a href="#ref-for-domtransition-finished-promise②">7.6. Update transition DOM</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-domtransition-skiptransition">
    <b><a href="#dom-domtransition-skiptransition">#dom-domtransition-skiptransition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domtransition-skiptransition">5.2. The DOMTransition interface</a>
-    <li><a href="#ref-for-dom-domtransition-skiptransition①">5.2.1. skipTransition()</a>
+    <li><a href="#ref-for-dom-domtransition-skiptransition">6.2. The DOMTransition interface</a>
+    <li><a href="#ref-for-dom-domtransition-skiptransition①">6.2.1. skipTransition()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="perform-pending-transition-operations">
    <b><a href="#perform-pending-transition-operations">#perform-pending-transition-operations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-perform-pending-transition-operations">6.1. Monkey patch to rendering</a>
-    <li><a href="#ref-for-perform-pending-transition-operations①">6.2. Perform pending transition operations</a>
+    <li><a href="#ref-for-perform-pending-transition-operations">7.1. Monkey patches to rendering</a>
+    <li><a href="#ref-for-perform-pending-transition-operations①">7.2. Perform pending transition operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="perform-an-outgoing-capture">
    <b><a href="#perform-an-outgoing-capture">#perform-an-outgoing-capture</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-perform-an-outgoing-capture">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-perform-an-outgoing-capture①">6.2. Perform pending transition operations</a>
-    <li><a href="#ref-for-perform-an-outgoing-capture②">6.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-perform-an-outgoing-capture">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-perform-an-outgoing-capture①">7.2. Perform pending transition operations</a>
+    <li><a href="#ref-for-perform-an-outgoing-capture②">7.3. Perform an outgoing capture</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="skip-the-page-transition">
    <b><a href="#skip-the-page-transition">#skip-the-page-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-skip-the-page-transition">5.1.1. createTransition()</a>
-    <li><a href="#ref-for-skip-the-page-transition①">5.2.1. skipTransition()</a>
-    <li><a href="#ref-for-skip-the-page-transition②">6.3. Perform an outgoing capture</a> <a href="#ref-for-skip-the-page-transition③">(2)</a> <a href="#ref-for-skip-the-page-transition④">(3)</a> <a href="#ref-for-skip-the-page-transition⑤">(4)</a> <a href="#ref-for-skip-the-page-transition⑥">(5)</a> <a href="#ref-for-skip-the-page-transition⑦">(6)</a> <a href="#ref-for-skip-the-page-transition⑧">(7)</a>
+    <li><a href="#ref-for-skip-the-page-transition">6.1.1. createTransition()</a>
+    <li><a href="#ref-for-skip-the-page-transition①">6.2.1. skipTransition()</a>
+    <li><a href="#ref-for-skip-the-page-transition②">7.3. Perform an outgoing capture</a> <a href="#ref-for-skip-the-page-transition③">(2)</a> <a href="#ref-for-skip-the-page-transition④">(3)</a> <a href="#ref-for-skip-the-page-transition⑤">(4)</a> <a href="#ref-for-skip-the-page-transition⑥">(5)</a> <a href="#ref-for-skip-the-page-transition⑦">(6)</a> <a href="#ref-for-skip-the-page-transition⑧">(7)</a> <a href="#ref-for-skip-the-page-transition⑨">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="capture-the-image">
    <b><a href="#capture-the-image">#capture-the-image</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-capture-the-image">6.3. Perform an outgoing capture</a> <a href="#ref-for-capture-the-image①">(2)</a>
-    <li><a href="#ref-for-capture-the-image②">6.5. Capture the image</a>
-    <li><a href="#ref-for-capture-the-image③">6.6. Update transition DOM</a>
-    <li><a href="#ref-for-capture-the-image④">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-capture-the-image">7.3. Perform an outgoing capture</a> <a href="#ref-for-capture-the-image①">(2)</a>
+    <li><a href="#ref-for-capture-the-image②">7.5. Capture the image</a>
+    <li><a href="#ref-for-capture-the-image③">7.6. Update transition DOM</a>
+    <li><a href="#ref-for-capture-the-image④">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="update-transition-dom">
    <b><a href="#update-transition-dom">#update-transition-dom</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-transition-dom">6.2. Perform pending transition operations</a>
-    <li><a href="#ref-for-update-transition-dom①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-update-transition-dom②">6.6. Update transition DOM</a>
+    <li><a href="#ref-for-update-transition-dom">7.2. Perform pending transition operations</a>
+    <li><a href="#ref-for-update-transition-dom①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-update-transition-dom②">7.6. Update transition DOM</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="computing-the-interest-rectangle">
    <b><a href="#computing-the-interest-rectangle">#computing-the-interest-rectangle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-computing-the-interest-rectangle">6.5. Capture the image</a>
-    <li><a href="#ref-for-computing-the-interest-rectangle①">6.7. Compute the interest rectangle</a>
+    <li><a href="#ref-for-computing-the-interest-rectangle">7.5. Capture the image</a>
+    <li><a href="#ref-for-computing-the-interest-rectangle①">7.7. Compute the interest rectangle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animate-a-page-transition">
    <b><a href="#animate-a-page-transition">#animate-a-page-transition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-animate-a-page-transition">3. Pseudo-elements</a> <a href="#ref-for-animate-a-page-transition①">(2)</a>
-    <li><a href="#ref-for-animate-a-page-transition②">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-animate-a-page-transition③">6.8. Animate a page transition</a>
+    <li><a href="#ref-for-animate-a-page-transition">4. Pseudo-elements</a> <a href="#ref-for-animate-a-page-transition①">(2)</a>
+    <li><a href="#ref-for-animate-a-page-transition②">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-animate-a-page-transition③">7.8. Animate a page transition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-transition-pseudo-elements">
    <b><a href="#create-transition-pseudo-elements">#create-transition-pseudo-elements</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-transition-pseudo-elements">3. Pseudo-elements</a>
-    <li><a href="#ref-for-create-transition-pseudo-elements①">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-create-transition-pseudo-elements②">6.9. Create transition pseudo-elements</a>
+    <li><a href="#ref-for-create-transition-pseudo-elements">4. Pseudo-elements</a>
+    <li><a href="#ref-for-create-transition-pseudo-elements①">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-create-transition-pseudo-elements②">7.9. Create transition pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="call-the-dom-change-callback">
-   <b><a href="#call-the-dom-change-callback">#call-the-dom-change-callback</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="call-the-dom-update-callback">
+   <b><a href="#call-the-dom-update-callback">#call-the-dom-update-callback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-call-the-dom-change-callback">6.3. Perform an outgoing capture</a>
-    <li><a href="#ref-for-call-the-dom-change-callback①">6.4. Skip the page transition</a>
+    <li><a href="#ref-for-call-the-dom-update-callback">7.3. Perform an outgoing capture</a>
+    <li><a href="#ref-for-call-the-dom-update-callback①">7.4. Skip the page transition</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This change is based on https://github.com/tabatkins/specs/pull/97.

I don't mind moving this PR to a new repo if we want to do that first.

Fixes https://github.com/WICG/shared-element-transitions/issues/19.