### PR TITLE
Fix the link to the most recent spec

### DIFF
--- a/css-anchor-position/index.bs
+++ b/css-anchor-position/index.bs
@@ -8,5 +8,5 @@ Work Status: exploring
 URL: http://tabatkins.github.io/specs/css-anchor-position
 Editor: Tab Atkins-Bittner, Google, http://xanthir.com/contact/, w3cid 42199
 Abstract: This specification defines 'anchor positioning', where a positioned element can size and position itself relative to one or more "anchor elements" elsewhere on the page.
-Warning: replaced by https://w3c.github.io/csswg-drafts/css-anchor/
+Warning: replaced by https://drafts.csswg.org/css-anchor-position-1/
 </pre>

--- a/css-anchor-position/index.html
+++ b/css-anchor-position/index.html
@@ -425,7 +425,7 @@ dfn > a.self-link::before      { content: "#"; }
    <div data-fill-with="warning">
     <details class="annoying-warning" open>
      <summary>This Document Is Obsolete and Has Been Replaced</summary>
-     <p> This specification is obsolete and has been replaced by the document at <a href="https://w3c.github.io/csswg-drafts/css-anchor/">https://w3c.github.io/csswg-drafts/css-anchor/</a>.
+     <p> This specification is obsolete and has been replaced by the document at <a href="https://drafts.csswg.org/css-anchor-position-1/">https://drafts.csswg.org/css-anchor-position-1/</a>.
 		Do not attempt to implement this specification.
 		Do not refer to this specification except as a historical artifact. </p>
     </details>


### PR DESCRIPTION
Hey hey!

I've noticed that https://w3c.github.io/csswg-drafts/css-anchor/ now gives a 404, and there is a different URL this new version of the spec is available — at https://drafts.csswg.org/css-anchor-position-1/, so fixed the redirect link.

(if there is a diff URL — let me know, also when looking into it, I saw that there is a `drafts4` subdomain on the csswg with the same content — would be cool to know what is the difference)